### PR TITLE
프로젝트 security를 포함한 기본 config 설정 및 util 클래스 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ $RECYCLE.BIN/
 
 ## etc
 application-mysql.yml
+application-private.yml

--- a/src/main/java/com/bungaebowling/server/_core/config/Configs.java
+++ b/src/main/java/com/bungaebowling/server/_core/config/Configs.java
@@ -1,0 +1,11 @@
+package com.bungaebowling.server._core.config;
+
+import java.util.Collections;
+import java.util.List;
+
+public class Configs {
+    public final static List<String> CORS = Collections.unmodifiableList(
+            List.of("http://localhost:3000", // 리액트 개발용 3000포트
+                        "*")  // 모든 IP 주소 허용 (나중에 프론트 앤드 IP만 허용하게 바꿔야함)
+    );
+}

--- a/src/main/java/com/bungaebowling/server/_core/config/Configs.java
+++ b/src/main/java/com/bungaebowling/server/_core/config/Configs.java
@@ -6,6 +6,6 @@ import java.util.List;
 public class Configs {
     public final static List<String> CORS = Collections.unmodifiableList(
             List.of("http://localhost:3000", // 리액트 개발용 3000포트
-                        "*")  // 모든 IP 주소 허용 (나중에 프론트 앤드 IP만 허용하게 바꿔야함)
+                    "http://127.0.0.1:3000")
     );
 }

--- a/src/main/java/com/bungaebowling/server/_core/errors/GlobalExceptionHandler.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.bungaebowling.server._core.errors;
+
+import com.bungaebowling.server._core.errors.exception.CustomException;
+import com.bungaebowling.server._core.errors.exception.client.Exception400;
+import com.bungaebowling.server._core.errors.exception.client.Exception401;
+import com.bungaebowling.server._core.errors.exception.client.Exception403;
+import com.bungaebowling.server._core.errors.exception.client.Exception404;
+import com.bungaebowling.server._core.errors.exception.server.Exception500;
+import com.bungaebowling.server._core.utils.ApiUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<?> customError(CustomException e) {
+        return ResponseEntity.status(e.status()).body(e.body());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> unknownServerError(Exception e) {
+        var status = HttpStatus.INTERNAL_SERVER_ERROR;
+        var response = ApiUtils.error(e.getMessage(), status);
+        return ResponseEntity.status(status).body(response);
+    }
+
+}

--- a/src/main/java/com/bungaebowling/server/_core/errors/GlobalValidationHandler.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/GlobalValidationHandler.java
@@ -1,0 +1,40 @@
+package com.bungaebowling.server._core.errors;
+
+import com.bungaebowling.server._core.errors.exception.client.Exception400;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+
+import java.util.Arrays;
+
+@Aspect
+@Component
+public class GlobalValidationHandler {
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping)")
+    public void postMapping() {}
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PutMapping)")
+    public void putMapping() {}
+
+    @Before("postMapping() || putMapping()")
+    public void validationAdvice(JoinPoint jp) {
+        Object[] args = jp.getArgs();
+
+        Arrays.stream(args)
+                .filter(arg -> arg instanceof Errors)
+                .forEach(arg -> {
+                    Errors errors = (Errors)  arg;
+
+                    if (errors.hasErrors()) {
+                        var error = errors.getFieldErrors().get(0);
+                        throw new Exception400(
+                                error.getDefaultMessage() + ":" + error.getField()
+                        );
+                    }
+                });
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/CustomException.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.bungaebowling.server._core.errors.exception;
+
+import com.bungaebowling.server._core.utils.ApiUtils;
+
+public abstract class CustomException extends RuntimeException{
+    public CustomException(String message) {
+        super(message);
+    }
+
+    public abstract Integer status();
+
+    public ApiUtils.Response<?> body() {
+        return ApiUtils.error(getMessage(), status());
+    }
+
+}

--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/client/Exception400.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/client/Exception400.java
@@ -1,0 +1,15 @@
+package com.bungaebowling.server._core.errors.exception.client;
+
+import com.bungaebowling.server._core.errors.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class Exception400 extends CustomException {
+    public Exception400(String message) {
+        super(message);
+    }
+
+    @Override
+    public Integer status() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/client/Exception401.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/client/Exception401.java
@@ -1,0 +1,15 @@
+package com.bungaebowling.server._core.errors.exception.client;
+
+import com.bungaebowling.server._core.errors.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class Exception401 extends CustomException {
+    public Exception401(String message) {
+        super(message);
+    }
+
+    @Override
+    public Integer status() {
+        return HttpStatus.UNAUTHORIZED.value();
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/client/Exception403.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/client/Exception403.java
@@ -1,0 +1,15 @@
+package com.bungaebowling.server._core.errors.exception.client;
+
+import com.bungaebowling.server._core.errors.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class Exception403 extends CustomException {
+    public Exception403(String message) {
+        super(message);
+    }
+
+    @Override
+    public Integer status() {
+        return HttpStatus.FORBIDDEN.value();
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/client/Exception404.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/client/Exception404.java
@@ -1,0 +1,15 @@
+package com.bungaebowling.server._core.errors.exception.client;
+
+import com.bungaebowling.server._core.errors.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class Exception404 extends CustomException {
+    public Exception404(String message) {
+        super(message);
+    }
+
+    @Override
+    public Integer status() {
+        return HttpStatus.NOT_FOUND.value();
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/server/Exception500.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/server/Exception500.java
@@ -1,0 +1,15 @@
+package com.bungaebowling.server._core.errors.exception.server;
+
+import com.bungaebowling.server._core.errors.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class Exception500 extends CustomException {
+    public Exception500(String message) {
+        super(message);
+    }
+
+    @Override
+    public Integer status() {
+        return HttpStatus.INTERNAL_SERVER_ERROR.value();
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/security/CustomSecurityFilterManager.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/CustomSecurityFilterManager.java
@@ -1,0 +1,14 @@
+package com.bungaebowling.server._core.security;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+
+public class CustomSecurityFilterManager extends AbstractHttpConfigurer<CustomSecurityFilterManager, HttpSecurity> {
+    @Override
+    public void configure(HttpSecurity builder) throws Exception {
+        AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
+        builder.addFilter(new JwtAuthenticationFilter(authenticationManager));
+        super.configure(builder);
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/security/CustomUserDetails.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package com.bungaebowling.server._core.security;
+
+import com.bungaebowling.server.user.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public record CustomUserDetails(User user) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        ArrayList<GrantedAuthority> auth = new ArrayList<>();
+        auth.add(new SimpleGrantedAuthority(user.getRole().toString()));
+        return auth;
+    }
+
+    public Long getId() {
+        return user.getId();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.bungaebowling.server._core.security;
+
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.bungaebowling.server.user.Role;
+import com.bungaebowling.server.user.User;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager) {
+        super(authenticationManager);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String jwt = request.getHeader(JwtProvider.HEADER);
+
+        if (jwt == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            DecodedJWT decodedJWT = JwtProvider.verify(jwt);
+            Long id = decodedJWT.getClaim("id").asLong();
+            Role role = decodedJWT.getClaim("role").as(Role.class);
+            User user = User.builder()
+                    .id(id)
+                    .role(role)
+                    .build();
+            CustomUserDetails userDetails = new CustomUserDetails(user);
+            Authentication authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            userDetails.getPassword(),
+                            userDetails.getAuthorities()
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("인증 객체 생성됨");
+        } catch (TokenExpiredException e) {
+            log.error("토큰 만료");
+        } catch (Exception e) {
+            log.error("토큰 검증 실패");
+        } finally {
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
@@ -1,0 +1,55 @@
+package com.bungaebowling.server._core.security;
+
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.bungaebowling.server.user.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+@Component
+public class JwtProvider {
+    public static final Long ACCESS_EXP_SECOND = 60L * 60 * 24 * 2; // 토큰 유효기간 2일 <- 개발용
+    public static final Long REFRESH_EXP_SECOND = 60L * 60 * 24 * 30; // 30일
+    public static final String TOKEN_PREFIX = "Bearer "; // 스페이스 필요함
+    public static final String HEADER = "Authorization";
+    private static String SECRET;
+
+    @Value("${bungaebowling.secret}")
+    public void setKey(String value) {
+        SECRET = value;
+    }
+
+    public static String createAccess(User user) {
+        LocalDateTime now = LocalDateTime.now();
+
+        LocalDateTime expired = now.plusSeconds(ACCESS_EXP_SECOND);
+        String jwt = JWT.create()
+                .withExpiresAt(Timestamp.valueOf(expired))
+                .withClaim("id", user.getId())
+                .withClaim("role", String.valueOf(user.getRole()))
+                .sign(Algorithm.HMAC512(SECRET));
+        return TOKEN_PREFIX + jwt;
+    }
+
+    public static String createRefresh(User user) {
+        // TODO: 리프레시 토큰에 무슨 데이터를 넣어야할 지 몰라서 임시로 id와 유효기간만 넣어놨습니다.
+        LocalDateTime now = LocalDateTime.now();
+
+        LocalDateTime expired = now.plusSeconds(REFRESH_EXP_SECOND);
+        String jwt = JWT.create()
+                .withExpiresAt(Timestamp.valueOf(expired))
+                .withClaim("id", user.getId())
+                .sign(Algorithm.HMAC512(SECRET));
+        return TOKEN_PREFIX + jwt;
+    }
+
+    public static DecodedJWT verify(String jwt) {
+        return JWT.require(Algorithm.HMAC512(SECRET)).build()
+                .verify(jwt.replace(TOKEN_PREFIX, ""));
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -74,6 +75,19 @@ public class SecurityConfig {
                     String responseBody = om.writeValueAsString(e.body());
                     response.getWriter().println(responseBody);
                 })));
+
+        // 10. 인증, 권한 필터 설정
+        http.authorizeHttpRequests(authorize ->
+                authorize
+                        .requestMatchers(new AntPathRequestMatcher("/api/posts/*/applicants", "GET")).hasRole("USER")
+                        .requestMatchers(new AntPathRequestMatcher("/api/posts/**", "GET")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/api/messages/**", "GET"),
+                                new AntPathRequestMatcher("/api/users/mine")).hasAnyRole("USER", "PENDING")
+                        .requestMatchers(new AntPathRequestMatcher("/api/posts/**"),
+                                new AntPathRequestMatcher("/api/applicants/**"),
+                                new AntPathRequestMatcher( "/api/messages/**")).hasRole("USER")
+                        .anyRequest().permitAll()
+        );
 
         return http.build();
     }

--- a/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
@@ -1,0 +1,66 @@
+package com.bungaebowling.server._core.security;
+
+import com.bungaebowling.server._core.config.Configs;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // 1. CSRF 해제
+        // SSR으로 스프링이 직접 페이지 만들어서 줄때는 csrf를 붙이는게 좋지만 프론트가 분리되어 있다면 그냥 해제하는게 낫다.
+        // Postman 에서 테스트할때도 csrf.disable 을 하지 않으면 에러가 발생한다.
+        http.csrf(AbstractHttpConfigurer::disable); // postman 접근해야 함!! - CSR 할때!!
+
+        // 2. iframe 거부
+        http.headers(headers ->
+                headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
+
+        // 3. cors 재설정
+        http.cors(cors ->
+                cors.configurationSource(configurationSource()));
+
+        // 4. jSessionId 가 응답이 될 때 세션영역에서 사라진다(JWT 로 stateless 하게 할거임)
+        http.sessionManagement(management ->
+                management.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // 5. form 로그인 해제해서 UsernamePasswordAuthenticationFilter 비활성화 시키기 (Form Post x-www-form-urlencoded)
+        http.formLogin(AbstractHttpConfigurer::disable);
+
+        // 6. 로그인 인증창이 뜨지 않도록 HttpBasicAuthenticationFilter 비활성화 (헤더에 username, password)
+        http.httpBasic(AbstractHttpConfigurer::disable);
+
+
+
+        return http.build();
+    }
+
+    public CorsConfigurationSource configurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*"); // GET, POST, PUT, DELETE (Javascript 요청 허용)
+        configuration.setAllowedOrigins(Configs.CORS);
+        configuration.setAllowCredentials(true); // 클라이언트에서 쿠키 요청 허용
+        configuration.addExposedHeader("Authorization"); // 헤더로 Authorization
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
         // 6. 로그인 인증창이 뜨지 않도록 HttpBasicAuthenticationFilter 비활성화 (헤더에 username, password)
         http.httpBasic(AbstractHttpConfigurer::disable);
 
-
+        // 7. 커스텀 필터들 적용 - 시큐리티 필터 커스텀으로 교체 (필터들을 갈아끼우는 내부 클래스)
+        http.apply(new CustomSecurityFilterManager());
 
         return http.build();
     }

--- a/src/main/java/com/bungaebowling/server/_core/utils/ApiUtils.java
+++ b/src/main/java/com/bungaebowling/server/_core/utils/ApiUtils.java
@@ -1,0 +1,28 @@
+package com.bungaebowling.server._core.utils;
+
+import org.springframework.http.HttpStatus;
+
+public class ApiUtils {
+
+    public static <T> Response<T> success(T response) {
+        return new Response<>(HttpStatus.OK.value(), response, null);
+    }
+
+    public static <T> Response<T> success() {
+        return new Response<>(HttpStatus.OK.value(), null, null);
+    }
+
+    public static <T> Response<T> error(String errorMessage, HttpStatus status) {
+        return new Response<>(status.value(), null, errorMessage);
+    }
+    public static <T> Response<T> error(String errorMessage, Integer status) {
+        return new Response<>(status, null, errorMessage);
+    }
+
+    public record Response<T>(
+            int status,
+            T response,
+            String errorMessage
+    ) {}
+
+}

--- a/src/main/java/com/bungaebowling/server/_core/utils/ValidList.java
+++ b/src/main/java/com/bungaebowling/server/_core/utils/ValidList.java
@@ -1,0 +1,16 @@
+package com.bungaebowling.server._core.utils;
+
+import jakarta.validation.Valid;
+import lombok.Data;
+import lombok.experimental.Delegate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class ValidList<E> implements List<E> {
+
+    @Valid
+    @Delegate
+    private List<E> list = new ArrayList<>();
+}

--- a/src/main/java/com/bungaebowling/server/_core/utils/cursor/CursorRequest.java
+++ b/src/main/java/com/bungaebowling/server/_core/utils/cursor/CursorRequest.java
@@ -1,0 +1,19 @@
+package com.bungaebowling.server._core.utils.cursor;
+
+public record CursorRequest(
+        Long key,
+        Integer size
+) {
+    public static final Long NONE_KEY = -1L;
+
+    public Boolean hasSize() {
+        return size != null;
+    }
+
+    public Boolean hasKey() {
+        return key != null;
+    }
+    public CursorRequest next(Long key) {
+        return new CursorRequest(key, size);
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/utils/cursor/PageCursor.java
+++ b/src/main/java/com/bungaebowling/server/_core/utils/cursor/PageCursor.java
@@ -1,0 +1,7 @@
+package com.bungaebowling.server._core.utils.cursor;
+
+public record PageCursor<T> (
+        CursorRequest nextCursorRequest,
+        T body
+) {
+}

--- a/src/main/java/com/bungaebowling/server/user/Role.java
+++ b/src/main/java/com/bungaebowling/server/user/Role.java
@@ -1,0 +1,6 @@
+package com.bungaebowling.server.user;
+
+public enum Role {
+    ROLE_PENDING,
+    ROLE_USER
+}

--- a/src/main/java/com/bungaebowling/server/user/User.java
+++ b/src/main/java/com/bungaebowling/server/user/User.java
@@ -1,0 +1,57 @@
+package com.bungaebowling.server.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_tb")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 20)
+    private String name;
+
+    @Column(length = 100, nullable = false, unique = true)
+    private String email;
+
+    @Column(length = 100, nullable = false)
+    private String password;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    private District district;
+
+    @Column(nullable = false)
+    private Long district_id; // District 만들고 District로 바꿔야함
+
+    @Column(length = 200)
+    private String imgUrl;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'ROLE_PENDING'")
+    @Column(length = 50)
+    private Role role;
+
+    @ColumnDefault("now()")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public User(Long id, String name, String email, String password, Long district_id, String imgUrl, Role role, LocalDateTime created_at) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.district_id = district_id;
+        this.imgUrl = imgUrl;
+        this.role = role;
+        this.createdAt = created_at;
+    }
+}

--- a/src/main/resources/application-private.yml.example
+++ b/src/main/resources/application-private.yml.example
@@ -1,0 +1,2 @@
+bungaebowling:
+  secret: bungaebowling

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,3 +2,4 @@ spring:
   profiles:
     active:
       - local
+      - private


### PR DESCRIPTION
## Summary

기본 configuration을 마쳐놓았습니다. 이제 api들을 바로 만들어도 될 거 같습니다.

## Description

프로젝트에 `spring security`를 포함시켰기 때문에 기본 설정을 하였습니다.
* `CORS`의 경우 `Configs `클래스에 허용하는 도메인들을 리스트로 작성하도록 분리시켜놨습니다.
  * 일단 임시로` "*"`를 추가하여 모든 도메인에 대해 허용시켰습니다.
* jwt 생성 및 해석하는 클래스를 만들었습니다.
  * jwt의 `SECRET`의 경우 `gitignore`로 관리하기 위해 `application-private.yml`을 추가로 만들었습니다.
  * `application-private.yml.example`을 복사해 `application-private.yml`을 생성하여 사용하시면 됩니다.
  * refresh 토큰의 경우, 임시로 작성해놨기 때문에 나중에 구현할 때 수정이 필요할 수 있습니다.
  * access 토큰에 포함되는 정보는 user의 id(pk)와 role입니다.
* jwt 인증 필터를 `security filter`에 포함시켰습니다.
  * 인증 실패 시 401, 권한 없을 시 403을 리턴하도록 필터에 핸들러를 추가하였습니다.
* Response 양식을 통일하기 위한 `Wrapper` 클래스를 만들었습니다.
* 추상 클래스 `CustomException`을 만들고 하위로 400, 401, 403, 404, 500 `Exception`을 만들었습니다.
* `GlobalExceptionHandler`로 `CustomException`들을 catch해 `errorResponse`를 주도록 구현했습니다.
* 마찬가지로 `POST`, `PUT`에 대해 `AOP Validation`을 위해 `ValidationHandler`를 생성하였습니다.
  * 추가적으로 `RequestBody`로 `List `형식의 `JSON`이 바로 들어올때, `@Valid`가 잘 적용되도록 `ValidList`를 만들었습니다.
  * `List `대신 `ValidList`를 사용해야 `@Valid`가 정상 동작합니다.
* `Cursor` 관련해서 `util` 클래스를 추가해두었습니다.(실제로 어떻게 사용할지는 추후 작업하며 생각해봐야할 거 같습니다)
* 현재의 api 명세서에 따라 `requestMatchers`를 작성하였습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #5 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->