### PR TITLE
redis를 사용한 리프레시 토큰과 함께 인증 시퀀스 완성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,0 +1,7 @@
+version: "3.5"
+services:
+  redis:
+    image: redis:6.2
+    container_name: redis
+    ports:
+      - "6379:6379"

--- a/src/main/java/com/bungaebowling/server/_core/config/RedisConfig.java
+++ b/src/main/java/com/bungaebowling/server/_core/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.bungaebowling.server._core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        // redisTemplate를 받아와서 set, get, delete를 사용
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        // setKeySerializer, setValueSerializer 설정
+        // redis-cli을 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/JwtAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
         }
 
         try {
-            DecodedJWT decodedJWT = JwtProvider.verify(jwt);
+            DecodedJWT decodedJWT = JwtProvider.verify(jwt, JwtProvider.TYPE_ACCESS);
             Long id = decodedJWT.getClaim("id").asLong();
             Role role = decodedJWT.getClaim("role").as(Role.class);
             User user = User.builder()

--- a/src/main/java/com/bungaebowling/server/_core/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/JwtAuthenticationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
 
         try {
             DecodedJWT decodedJWT = JwtProvider.verify(jwt, JwtProvider.TYPE_ACCESS);
-            Long id = decodedJWT.getClaim("id").asLong();
+            Long id = Long.valueOf(decodedJWT.getSubject());
             Role role = decodedJWT.getClaim("role").as(Role.class);
             User user = User.builder()
                     .id(id)

--- a/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
@@ -33,21 +33,21 @@ public class JwtProvider {
         String jwt = JWT.create()
                 .withSubject(user.getId().toString())
                 .withClaim("role", String.valueOf(user.getRole()))
+                .withClaim("type", "access")
                 .withExpiresAt(Timestamp.valueOf(expired))
                 .sign(Algorithm.HMAC512(SECRET));
         return TOKEN_PREFIX + jwt;
     }
 
     public static String createRefresh(User user) {
-        // TODO: 리프레시 토큰에 무슨 데이터를 넣어야할 지 몰라서 임시로 id와 유효기간만 넣어놨습니다.
         LocalDateTime now = LocalDateTime.now();
 
         LocalDateTime expired = now.plusSeconds(REFRESH_EXP_SECOND);
-        String jwt = JWT.create()
+        return JWT.create()
                 .withSubject(user.getId().toString())
+                .withClaim("type", "refresh")
                 .withExpiresAt(Timestamp.valueOf(expired))
                 .sign(Algorithm.HMAC512(SECRET));
-        return TOKEN_PREFIX + jwt;
     }
 
     public static DecodedJWT verify(String jwt) {

--- a/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
@@ -7,6 +7,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.bungaebowling.server._core.errors.exception.client.Exception401;
 import com.bungaebowling.server.user.User;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -16,47 +17,60 @@ import java.util.Objects;
 
 @Component
 public class JwtProvider {
-    public static final Long ACCESS_EXP_SECOND = 60L * 60 * 24 * 2; // 토큰 유효기간 2일 <- 개발용
-    public static final Long REFRESH_EXP_SECOND = 60L * 60 * 24 * 30; // 30일
     public static final String TOKEN_PREFIX = "Bearer "; // 스페이스 필요함
     public static final String HEADER = "Authorization";
     public static final String TYPE_ACCESS = "access";
     public static final String TYPE_REFRESH = "refresh";
     public static final String TYPE_EMAIL_VERIFICATION = "email-verification";
-    private static String SECRET;
+
+    @Getter
+    private static Long accessExpSecond;
+    @Getter
+    private static Long refreshExpSecond;
+    private static String secret;
+
+    @Value("${bungaebowling.token_exp.access}")
+    private void setAccessExpSecond(Long value) {
+        accessExpSecond = value;
+    }
+
+    @Value("${bungaebowling.token_exp.refresh}")
+    private void setRefreshExpSecond(Long value) {
+        refreshExpSecond = value;
+    }
 
     @Value("${bungaebowling.secret}")
-    public void setKey(String value) {
-        SECRET = value;
+    private void setSecret(String value) {
+        secret = value;
     }
 
     public static String createAccess(User user) {
         LocalDateTime now = LocalDateTime.now();
 
-        LocalDateTime expired = now.plusSeconds(ACCESS_EXP_SECOND);
+        LocalDateTime expired = now.plusSeconds(accessExpSecond);
         String jwt = JWT.create()
                 .withSubject(user.getId().toString())
                 .withClaim("role", String.valueOf(user.getRole()))
                 .withClaim("type", TYPE_ACCESS)
                 .withExpiresAt(Timestamp.valueOf(expired))
-                .sign(Algorithm.HMAC512(SECRET));
+                .sign(Algorithm.HMAC512(secret));
         return TOKEN_PREFIX + jwt;
     }
 
     public static String createRefresh(User user) {
         LocalDateTime now = LocalDateTime.now();
 
-        LocalDateTime expired = now.plusSeconds(REFRESH_EXP_SECOND);
+        LocalDateTime expired = now.plusSeconds(refreshExpSecond);
         return JWT.create()
                 .withSubject(user.getId().toString())
                 .withClaim("type", TYPE_REFRESH)
                 .withExpiresAt(Timestamp.valueOf(expired))
-                .sign(Algorithm.HMAC512(SECRET));
+                .sign(Algorithm.HMAC512(secret));
     }
 
     public static DecodedJWT verify(String jwt, String type) {
         try {
-            DecodedJWT decodedJwt = JWT.require(Algorithm.HMAC512(SECRET)).build()
+            DecodedJWT decodedJwt = JWT.require(Algorithm.HMAC512(secret)).build()
                     .verify(jwt.replace(TOKEN_PREFIX, ""));
             
             if (!Objects.equals(decodedJwt.getClaim("type").asString(), type)) {

--- a/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
@@ -82,7 +82,8 @@ public class SecurityConfig {
                         .requestMatchers(new AntPathRequestMatcher("/api/posts/*/applicants", "GET")).hasRole("USER")
                         .requestMatchers(new AntPathRequestMatcher("/api/posts/**", "GET")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/messages/**", "GET"),
-                                new AntPathRequestMatcher("/api/users/mine")).hasAnyRole("USER", "PENDING")
+                                new AntPathRequestMatcher("/api/users/mine"),
+                                new AntPathRequestMatcher("/api/logout")).hasAnyRole("USER", "PENDING")
                         .requestMatchers(new AntPathRequestMatcher("/api/posts/**"),
                                 new AntPathRequestMatcher("/api/applicants/**"),
                                 new AntPathRequestMatcher( "/api/messages/**")).hasRole("USER")

--- a/src/main/java/com/bungaebowling/server/_core/utils/ApiUtils.java
+++ b/src/main/java/com/bungaebowling/server/_core/utils/ApiUtils.java
@@ -8,8 +8,24 @@ public class ApiUtils {
         return new Response<>(HttpStatus.OK.value(), response, null);
     }
 
+    public static <T> Response<T> success(T response, HttpStatus status) {
+        return new Response<>(status.value(), response, null);
+    }
+
+    public static <T> Response<T> success(T response, Integer status) {
+        return new Response<>(status, response, null);
+    }
+
     public static <T> Response<T> success() {
         return new Response<>(HttpStatus.OK.value(), null, null);
+    }
+
+    public static <T> Response<T> success(HttpStatus status) {
+        return new Response<>(status.value(), null, null);
+    }
+
+    public static <T> Response<T> success(Integer status) {
+        return new Response<>(status, null, null);
     }
 
     public static <T> Response<T> error(String errorMessage, HttpStatus status) {

--- a/src/main/java/com/bungaebowling/server/user/User.java
+++ b/src/main/java/com/bungaebowling/server/user/User.java
@@ -18,7 +18,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 20)
+    @Column(length = 20, nullable = false, unique = true)
     private String name;
 
     @Column(length = 100, nullable = false, unique = true)

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
     final private UserService userService;
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody @Valid UserRequest.loginDto requestDto, Errors errors) {
+    public ResponseEntity<?> login(@RequestBody @Valid UserRequest.LoginDto requestDto, Errors errors) {
         var tokens = userService.login(requestDto);
 
         var responseCookie = createRefreshTokenCookie(tokens.refresh());

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -12,12 +12,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,6 +31,13 @@ import java.util.List;
 public class UserController {
 
     final private UserService userService;
+
+    @PostMapping("/join")
+    public ResponseEntity<?> join(@RequestBody @Valid UserRequest.JoinDto requestDto, Errors errors) throws URISyntaxException {
+
+        var response = ApiUtils.success(HttpStatus.CREATED);
+        return ResponseEntity.created(new URI("/api/users/3")).body(response);
+    }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserRequest.LoginDto requestDto, Errors errors) {

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.bungaebowling.server.user.controller;
 
 
+import com.bungaebowling.server._core.security.CustomUserDetails;
 import com.bungaebowling.server._core.security.JwtProvider;
 import com.bungaebowling.server._core.utils.ApiUtils;
 import com.bungaebowling.server._core.utils.cursor.CursorRequest;
@@ -13,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,11 +36,25 @@ public class UserController {
         ResponseCookie responseCookie = ResponseCookie.from("refreshToken", tokens.refresh())
                 .httpOnly(true) // javascript 접근 방지
                 .secure(true) // https 통신 강제
+                .maxAge(JwtProvider.REFRESH_EXP_SECOND)
                 .build();
 
         var response = ApiUtils.success();
         return ResponseEntity.ok().header(JwtProvider.HEADER, tokens.access())
                 .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.logout(userDetails.getId());
+
+        ResponseCookie responseCookie = ResponseCookie.from("refreshToken", "")
+                .maxAge(0)
+                .build();
+
+        var response = ApiUtils.success();
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString())
                 .body(response);
     }
 

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -1,15 +1,17 @@
 package com.bungaebowling.server.user.controller;
 
 
+import com.bungaebowling.server._core.security.JwtProvider;
 import com.bungaebowling.server._core.utils.ApiUtils;
 import com.bungaebowling.server._core.utils.cursor.CursorRequest;
+import com.bungaebowling.server.user.dto.UserRequest;
 import com.bungaebowling.server.user.dto.UserResponse;
+import com.bungaebowling.server.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,16 @@ import java.util.List;
 @RestController
 @RequestMapping("/api")
 public class UserController {
+
+    final private UserService userService;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody @Valid UserRequest.loginDto requestDto, Errors errors) {
+        String access = userService.login(requestDto);
+
+        var response = ApiUtils.success();
+        return ResponseEntity.ok().header(JwtProvider.HEADER, access).body(response);
+    }
 
     @GetMapping("/users")
     public ResponseEntity<?> getUsers() {

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -34,9 +34,15 @@ public class UserController {
 
     @PostMapping("/join")
     public ResponseEntity<?> join(@RequestBody @Valid UserRequest.JoinDto requestDto, Errors errors) throws URISyntaxException {
+        var responseDto = userService.join(requestDto);
+
+        var responseCookie = createRefreshTokenCookie(responseDto.refresh());
 
         var response = ApiUtils.success(HttpStatus.CREATED);
-        return ResponseEntity.created(new URI("/api/users/3")).body(response);
+        return ResponseEntity.created(new URI("/api/users/" + responseDto.savedId()))
+                .header(JwtProvider.HEADER, responseDto.access())
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(response);
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -148,7 +148,7 @@ public class UserController {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true) // javascript 접근 방지
                 .secure(true) // https 통신 강제
-                .maxAge(JwtProvider.REFRESH_EXP_SECOND)
+                .maxAge(JwtProvider.getRefreshExpSecond())
                 .build();
     }
 }

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -31,8 +31,6 @@ public class UserController {
     public ResponseEntity<?> login(@RequestBody @Valid UserRequest.loginDto requestDto, Errors errors) {
         UserResponse.TokensDto tokens = userService.login(requestDto);
 
-
-
         ResponseCookie responseCookie = ResponseCookie.from("refreshToken", tokens.refresh())
                 .httpOnly(true) // javascript 접근 방지
                 .secure(true) // https 통신 강제

--- a/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
@@ -1,5 +1,7 @@
 package com.bungaebowling.server.user.dto;
 
+import com.bungaebowling.server.city.country.district.District;
+import com.bungaebowling.server.user.User;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -24,5 +26,14 @@ public class UserRequest {
             String password,
             @NotEmpty
             String districtId
-    ) {}
+    ) {
+        public User createUser(District district, String encodedPassword) {
+            return User.builder()
+                    .name(name)
+                    .email(email)
+                    .password(encodedPassword)
+                    .district(district)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
@@ -1,0 +1,14 @@
+package com.bungaebowling.server.user.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+public class UserRequest {
+
+    public record loginDto(
+            @NotEmpty @Size(max=100, message = "최대 100자까지 입력 가능합니다.")
+            String email,
+            @NotEmpty @Size(max = 64, message = "최대 64자까지 입력 가능합니다.")
+            String password
+    ) {}
+}

--- a/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
@@ -1,14 +1,28 @@
 package com.bungaebowling.server.user.dto;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public class UserRequest {
 
-    public record loginDto(
+    public record LoginDto(
             @NotEmpty @Size(max=100, message = "최대 100자까지 입력 가능합니다.")
             String email,
             @NotEmpty @Size(max = 64, message = "최대 64자까지 입력 가능합니다.")
             String password
+    ) {}
+
+    public record JoinDto(
+            @Size(max = 20, message = "최대 20자까지 입니다.")
+            String name,
+            @NotEmpty @Size(max = 100, message = "최대 100자까지 입니다.")
+            @Pattern(regexp = "^[\\w.%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$", message = "이메일 형식이 아닙니다.")
+            String email,
+            @NotEmpty @Size(min = 8, max = 64, message = "8자에서 64자 이내여야 합니다.")
+            @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@#$%^&!])[a-zA-Z\\d@#$%^&!]+$", message = "영문, 숫자, 특수문자가 포함되어야 합니다.")
+            String password,
+            @NotEmpty
+            String districtId
     ) {}
 }

--- a/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
@@ -39,6 +39,12 @@ public class UserResponse {
 
     }
 
+    public record JoinDto(
+            Long savedId,
+            String access,
+            String refresh
+    ) {}
+
     public record TokensDto(
             String access,
             String refresh

--- a/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
@@ -38,4 +38,9 @@ public class UserResponse {
     ) {
 
     }
+
+    public record TokensDto(
+            String access,
+            String refresh
+    ) {}
 }

--- a/src/main/java/com/bungaebowling/server/user/repository/UserRepository.java
+++ b/src/main/java/com/bungaebowling/server/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByName(String name);
 }

--- a/src/main/java/com/bungaebowling/server/user/repository/UserRepository.java
+++ b/src/main/java/com/bungaebowling/server/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.bungaebowling.server.user.repository;
+
+import com.bungaebowling.server.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -1,0 +1,32 @@
+package com.bungaebowling.server.user.service;
+
+import com.bungaebowling.server._core.errors.exception.client.Exception400;
+import com.bungaebowling.server._core.security.JwtProvider;
+import com.bungaebowling.server.user.User;
+import com.bungaebowling.server.user.dto.UserRequest;
+import com.bungaebowling.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    final private UserRepository userRepository;
+
+
+    final private PasswordEncoder passwordEncoder;
+
+    public String login(UserRequest.loginDto requestDto) {
+        User user = userRepository.findByEmail(requestDto.email()).orElseThrow(() ->
+                new Exception400("이메일 혹은 비밀번호가 일치하지 않습니다."));
+
+        if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
+            throw new Exception400("이메일 혹은 비밀번호가 일치하지 않습니다.");
+        }
+        return JwtProvider.createAccess(user);
+    }
+}

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.bungaebowling.server._core.errors.exception.client.Exception400;
 import com.bungaebowling.server._core.security.JwtProvider;
 import com.bungaebowling.server.user.User;
 import com.bungaebowling.server.user.dto.UserRequest;
+import com.bungaebowling.server.user.dto.UserResponse;
 import com.bungaebowling.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,13 +21,17 @@ public class UserService {
 
     final private PasswordEncoder passwordEncoder;
 
-    public String login(UserRequest.loginDto requestDto) {
+    public UserResponse.TokensDto login(UserRequest.loginDto requestDto) {
         User user = userRepository.findByEmail(requestDto.email()).orElseThrow(() ->
                 new Exception400("이메일 혹은 비밀번호가 일치하지 않습니다."));
 
         if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
             throw new Exception400("이메일 혹은 비밀번호가 일치하지 않습니다.");
         }
-        return JwtProvider.createAccess(user);
+
+        var access = JwtProvider.createAccess(user);
+        var refresh = JwtProvider.createRefresh(user);
+
+        return new UserResponse.TokensDto(access, refresh);
     }
 }

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -93,7 +93,7 @@ public class UserService {
         redisTemplate.opsForValue().set(
                 user.getId().toString(),
                 refresh,
-                JwtProvider.REFRESH_EXP_SECOND,
+                JwtProvider.getRefreshExpSecond(),
                 TimeUnit.SECONDS
         );
 

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
 
     final private PasswordEncoder passwordEncoder;
 
-    public UserResponse.TokensDto login(UserRequest.loginDto requestDto) {
+    public UserResponse.TokensDto login(UserRequest.LoginDto requestDto) {
         var user = userRepository.findByEmail(requestDto.email()).orElseThrow(() ->
                 new Exception400("이메일 혹은 비밀번호가 일치하지 않습니다."));
 

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -2,7 +2,6 @@ package com.bungaebowling.server.user.service;
 
 import com.bungaebowling.server._core.errors.exception.client.Exception400;
 import com.bungaebowling.server._core.security.JwtProvider;
-import com.bungaebowling.server.user.User;
 import com.bungaebowling.server.user.dto.UserRequest;
 import com.bungaebowling.server.user.dto.UserResponse;
 import com.bungaebowling.server.user.repository.UserRepository;
@@ -26,7 +25,7 @@ public class UserService {
     final private PasswordEncoder passwordEncoder;
 
     public UserResponse.TokensDto login(UserRequest.loginDto requestDto) {
-        User user = userRepository.findByEmail(requestDto.email()).orElseThrow(() ->
+        var user = userRepository.findByEmail(requestDto.email()).orElseThrow(() ->
                 new Exception400("이메일 혹은 비밀번호가 일치하지 않습니다."));
 
         if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
@@ -44,5 +43,9 @@ public class UserService {
         );
 
         return new UserResponse.TokensDto(access, refresh);
+    }
+
+    public void logout(Long id) {
+        redisTemplate.delete(id.toString());
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -39,3 +39,8 @@ logging:
       orm.jdbc:
         extract: TRACE
         bind: TRACE
+
+bungaebowling:
+  token_exp:
+    access: 172800
+    refresh: 2592000

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,6 +26,10 @@ spring:
   sql:
     init:
       encoding: utf-8
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 logging:
   level:

--- a/src/main/resources/application-product.yml
+++ b/src/main/resources/application-product.yml
@@ -21,6 +21,10 @@ spring:
     init:
       mode: never
       encoding: utf-8
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 logging:
   level:

--- a/src/main/resources/application-product.yml
+++ b/src/main/resources/application-product.yml
@@ -29,3 +29,8 @@ spring:
 logging:
   level:
     com.bungaebowling.server: INFO
+
+bungaebowling:
+  token_exp:
+    access: 600
+    refresh: 2592000

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -52,3 +52,7 @@ VALUES (0, 1, '신사동'),
        (0, 7, '서동'),
        (0, 7, '장전동'),
        (0, 7, '청룡노포동');
+
+-- 비밀번호는 test12!@
+INSERT INTO user_tb (name, email, password, district_id, role)
+VALUES ('김볼링', 'test@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');


### PR DESCRIPTION
## Summary

redis의 경우 도커로 띄웠고, 액세스 토큰과 리프레시 토큰을 구현 완료 하였습니다. api 적인 관점에서는
- 회원가입
- 로그인
- 로그아웃
- 토큰 재발급

총 4가지의 api를 구현하였습니다.

## Description

### redis

redis의 경우 docker-compose-redis.yml을 통해 컨테이너를 만들었습니다. 개발/ 배포 profile에 전부 redis 설정을 집어 넣었습니다.

```sh
$ docker-compose -f docker-compose-redis.yml up
```

명령어로 레디스 컨테이너를 실행하실 수 있습니다. 혹은, intelliJ의 run configuration으로도 설정가능합니다.

![image](https://github.com/Step3-kakao-tech-campus/Team3_BE/assets/84557643/b3be6291-c976-4663-81a2-f25cbc6fa5cf)

redis에 직접 접근하여 값을 보고 싶은 경우,

```sh
$ docker exec -it redis redis-cli
127.0.0.1:6379> keys *
(empty array)
                                                     #  로그인 진행 후
127.0.0.1:6379> keys *
1) "1"
127.0.0.1:6379> get 1
"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwidHlwZSI6InJlZnJlc2giLCJleHAiOjE2OTgzNDc2NzR9.P71t6HS1NHKsUmTSpmthEnzN0Md2WMdbcTP10Udkg3N5kNOtjO8WgKQII3L2G8hF-Gw3TnvuoYXBOXfRVM3WKg"
127.0.0.1:6379> del 1
(integer) 1
127.0.0.1:6379> keys *
(empty array)
```

위와 같이 파악한 명령어는 `keys`, `get`, `del`이 있습니다.

레디스는 key-value로 값을 저장되기 때문에, 회원 ID(PK)를 key로 하여 refresh 토큰을 value로 저장합니다.

### API

테스트의 용이성을 위해 data.sql에 김볼링을 더미 데이터로 집어넣었습니다.
- 이메일: test@test.com
- 비밀번호: test12!@ 로 로그인 가능합니다.

---
- **로그인을 구현했습니다.**
  - 액세스 토큰과 리프레시 토큰을 발급하며 리프레시 토큰은 레디스에 저장합니다.
  - JWT의 구조를 변경하여 type이라는 claim을 추가하였습니다.
  - JWT verify로 decode를 할 때, type을 파라미터로 받아 타입이 일치하지 않으면 Exception이 발생하도록 구현하였습니다.
  - 인증과정에서 id(claim)이 subject로 변경되었었는데, 여전히 claim의 id를 접근하던 버그를 수정했습니다.
- **로그아웃을 구현했습니다.**
  - 로그아웃 시, 쿠키를 만료 시키며, 레디스의 리프레시 토큰을 삭제합니다.
- **토큰 재발급을 구현했습니다.**
  - 재발급은 아이디, 비밀번호 대신 리프레시 토큰으로 인증하여 로그인하는 것과 같습니다.(똑같이 액세스, 리프레시 발급함)
  - 따라서 로그인 api와 구조가 유사합니다.
  - 기존의 리프레시 토큰의 경우는, 새로 발급한 토큰이 기존 토큰 위에 덮어씌워져서 사라지므로 기존 토큰 삭제 로직은 별도로 필요가 없습니다.
- **회원가입을 구현했습니다.**
  - 유효성 검사 정규식과 제약들을 작성했습니다. 다른 api 제작 시 참고 부탁드립니다.
  - 닉네임이 원래 중복 허용이 되었는데 닉네임으로 검색 시 같은 닉네임이 있으면 안될 거 같아 unique 제약을 추가하였습니다.
  - 이제 닉네임은 중복 불가이며 입력 필수입니다.
- 성공 응답이 201로 명세가 되어 있어 success에도 상태코드 변경이 가능하도록 확장시켰습니다.
- 토큰의 만료 시간을 application.yml에서 관리하게 변경하였습니다.
  - 개발 서버의 경우, 액세스 2일, 리프레시 30일 / 배포 서버의 경우, 액세스 10분, 리프레시 30일입니다.

> 프론트 측에서 회원가입/로그인 api를 요청하여서 review가 안된 코드지만, 일단 이 브랜치를 기준으로 바로 배포 중입니다.

**노션의 BE 아카이브에 가이드를 추가하였으니 이것도 확인 부탁드립니다!**
- [🐋도커 redis 서버 실행](https://www.notion.so/redis-69f2b3d150a64356b1228e5b581266a8)
- [🚀로그인 관련 포스트맨 설정법](https://www.notion.so/1493f692bef441388418272c228cd4dd)

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #11 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->