### PR TITLE
신청 API 구현

### DIFF
--- a/src/main/java/com/bungaebowling/server/applicant/Applicant.java
+++ b/src/main/java/com/bungaebowling/server/applicant/Applicant.java
@@ -35,6 +35,9 @@ public class Applicant {
     @JoinColumn(name = "post_id", referencedColumnName = "id")
     private Post post;
 
+    //@OneToOne
+    //private UserRate userRate;
+
     @ColumnDefault("now()")
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/bungaebowling/server/applicant/Applicant.java
+++ b/src/main/java/com/bungaebowling/server/applicant/Applicant.java
@@ -16,20 +16,23 @@ import java.time.LocalDateTime;
 @Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name="applicant_tb", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"user_id", "post_id"})
-})
+@Table(name="applicant_tb")
+//@Table(name="applicant_tb", uniqueConstraints = {
+//        @UniqueConstraint(columnNames = {"user_id", "post_id"})
+//})
 public class Applicant {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ColumnDefault("false")
-    private boolean status;
+    private Boolean status;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "id")
-    private User user;
+    private Long userId; //임시
+
+//    @ManyToOne
+//    @JoinColumn(name = "user_id", referencedColumnName = "id")
+//    private User user;
 
     @ManyToOne
     @JoinColumn(name = "post_id", referencedColumnName = "id")
@@ -42,10 +45,10 @@ public class Applicant {
     private LocalDateTime createdAt;
 
     @Builder
-    public Applicant(Long id, boolean status, User user, Post post, LocalDateTime createdAt) {
+    public Applicant(Long id, Boolean status, Long userId, Post post, LocalDateTime createdAt) {
         this.id = id;
         this.status = status;
-        this.user = user;
+        this.userId = userId;
         this.post = post;
         this.createdAt = createdAt;
     }

--- a/src/main/java/com/bungaebowling/server/applicant/Applicant.java
+++ b/src/main/java/com/bungaebowling/server/applicant/Applicant.java
@@ -16,10 +16,9 @@ import java.time.LocalDateTime;
 @Getter
 @DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name="applicant_tb")
-//@Table(name="applicant_tb", uniqueConstraints = {
-//        @UniqueConstraint(columnNames = {"user_id", "post_id"})
-//})
+@Table(name="applicant_tb", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "post_id"})
+})
 public class Applicant {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,11 +27,9 @@ public class Applicant {
     @ColumnDefault("false")
     private Boolean status;
 
-    private Long userId; //임시
-
-//    @ManyToOne
-//    @JoinColumn(name = "user_id", referencedColumnName = "id")
-//    private User user;
+    @ManyToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
 
     @ManyToOne
     @JoinColumn(name = "post_id", referencedColumnName = "id")
@@ -45,10 +42,10 @@ public class Applicant {
     private LocalDateTime createdAt;
 
     @Builder
-    public Applicant(Long id, Boolean status, Long userId, Post post, LocalDateTime createdAt) {
+    public Applicant(Long id, Boolean status, User user, Post post, LocalDateTime createdAt) {
         this.id = id;
         this.status = status;
-        this.userId = userId;
+        this.user = user;
         this.post = post;
         this.createdAt = createdAt;
     }

--- a/src/main/java/com/bungaebowling/server/applicant/Applicant.java
+++ b/src/main/java/com/bungaebowling/server/applicant/Applicant.java
@@ -1,0 +1,49 @@
+package com.bungaebowling.server.applicant;
+
+import com.bungaebowling.server.post.Post;
+import com.bungaebowling.server.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name="applicant_tb", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "post_id"})
+})
+public class Applicant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ColumnDefault("false")
+    private boolean status;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", referencedColumnName = "id")
+    private Post post;
+
+    @ColumnDefault("now()")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Applicant(Long id, boolean status, User user, Post post, LocalDateTime createdAt) {
+        this.id = id;
+        this.status = status;
+        this.user = user;
+        this.post = post;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/bungaebowling/server/applicant/Applicant.java
+++ b/src/main/java/com/bungaebowling/server/applicant/Applicant.java
@@ -49,4 +49,8 @@ public class Applicant {
         this.post = post;
         this.createdAt = createdAt;
     }
+
+    public void updateStatus(Boolean status){
+        this.status = status;
+    }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -22,27 +22,27 @@ public class ApplicantController {
     @GetMapping
     public ResponseEntity<?> getApplicants(@PathVariable Long postId, CursorRequest cursorRequest,
                                            @AuthenticationPrincipal CustomUserDetails userDetails){
-        PageCursor<ApplicantResponse.GetApplicantsDto> getApplicantsDto = applicantService.getApplicants(userDetails.getId(), postId, cursorRequest);
+        PageCursor<ApplicantResponse.GetApplicantsDto> getApplicantsDto = applicantService.getApplicants(1L, postId, cursorRequest);
         var response = ApiUtils.success(getApplicantsDto);
         return ResponseEntity.ok().body(response);
     }
 
     @PostMapping
     public ResponseEntity<?> create(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        applicantService.create(userDetails.getId(), postId);
+        applicantService.create(null, postId);
         return ResponseEntity.ok(ApiUtils.success());
     }
 
     @PutMapping("/{applicantId}")
-    public ResponseEntity<?> update(@PathVariable Long applicantId, ApplicantRequest.UpdateDto requestDto,
+    public ResponseEntity<?> accept(@PathVariable Long applicantId, @RequestBody ApplicantRequest.UpdateDto requestDto,
                                     @AuthenticationPrincipal CustomUserDetails userDetails){
-        applicantService.update(userDetails.getId(), applicantId, requestDto);
+        applicantService.accept(applicantId, requestDto);
         return ResponseEntity.ok(ApiUtils.success());
     }
 
     @DeleteMapping("/{applicantId}")
-    public ResponseEntity<?> delete(@PathVariable Long applicantId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        applicantService.delete(userDetails.getId(), applicantId);
+    public ResponseEntity<?> reject(@PathVariable Long applicantId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        applicantService.reject(applicantId);
         return ResponseEntity.ok(ApiUtils.success());
     }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -35,7 +36,7 @@ public class ApplicantController {
     }
 
     @PutMapping("/{applicantId}")
-    public ResponseEntity<?> accept(@PathVariable Long applicantId, @RequestBody @Valid ApplicantRequest.UpdateDto requestDto,){
+    public ResponseEntity<?> accept(@PathVariable Long applicantId, @RequestBody @Valid ApplicantRequest.UpdateDto requestDto, Errors errors){
         applicantService.accept(applicantId, requestDto);
         return ResponseEntity.ok(ApiUtils.success());
     }

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -1,7 +1,13 @@
 package com.bungaebowling.server.applicant.controller;
 
+import com.bungaebowling.server._core.security.CustomUserDetails;
+import com.bungaebowling.server._core.utils.ApiUtils;
+import com.bungaebowling.server._core.utils.cursor.CursorRequest;
+import com.bungaebowling.server.applicant.dto.ApplicantResponse;
+import com.bungaebowling.server.applicant.service.ApplicantService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -9,23 +15,33 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/posts/{postId}/applicants")
 public class ApplicantController {
 
+    private final ApplicantService applicantService;
+
     @GetMapping
-    public ResponseEntity<?> getApplicants(){
-        return ResponseEntity.ok().body();
+    public ResponseEntity<?> getApplicants(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails,
+                                           CursorRequest cursorRequest){
+        ApplicantResponse.GetApplicantsDto getApplicantsDto = applicantService.getApplicants(userDetails.getId(), postId, cursorRequest);
+        var response = ApiUtils.success(getApplicantsDto);
+        return ResponseEntity.ok().body(response);
     }
 
     @PostMapping
-    public ResponseEntity<?> apply(){
+    public ResponseEntity<?> apply(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        applicantService.apply();
         return ResponseEntity.ok().body();
     }
 
     @PutMapping("/{applicantId}")
-    public ResponseEntity<?> accept(){
+    public ResponseEntity<?> accept(@PathVariable Long postId, @PathVariable Long applicantId,
+                                    @AuthenticationPrincipal CustomUserDetails userDetails){
+        applicantService.accept();
         return ResponseEntity.ok().body();
     }
 
     @DeleteMapping("/{applicantId}")
-    public ResponseEntity<?> reject(){
+    public ResponseEntity<?> reject(@PathVariable Long postId, @PathVariable Long applicantId,
+                                    @AuthenticationPrincipal CustomUserDetails userDetails){
+        applicantService.reject();
         return ResponseEntity.ok().body();
     }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -4,6 +4,7 @@ import com.bungaebowling.server._core.security.CustomUserDetails;
 import com.bungaebowling.server._core.utils.ApiUtils;
 import com.bungaebowling.server._core.utils.cursor.CursorRequest;
 import com.bungaebowling.server._core.utils.cursor.PageCursor;
+import com.bungaebowling.server.applicant.dto.ApplicantRequest;
 import com.bungaebowling.server.applicant.dto.ApplicantResponse;
 import com.bungaebowling.server.applicant.service.ApplicantService;
 import lombok.RequiredArgsConstructor;
@@ -34,8 +35,9 @@ public class ApplicantController {
 
     @PutMapping("/{applicantId}")
     public ResponseEntity<?> update(@PathVariable Long postId, @PathVariable Long applicantId,
+                                    ApplicantRequest.UpdateDto requestDto,
                                     @AuthenticationPrincipal CustomUserDetails userDetails){
-        applicantService.update(userDetails.getId(), applicantId);
+        applicantService.update(userDetails.getId(), applicantId, requestDto);
         return ResponseEntity.ok(ApiUtils.success());
     }
 

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -31,7 +31,7 @@ public class ApplicantController {
 
     @PostMapping
     public ResponseEntity<?> create(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        applicantService.create(userDetails.user(), postId);
+        applicantService.create(userDetails.getId(), postId);
         return ResponseEntity.ok(ApiUtils.success());
     }
 

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -1,0 +1,31 @@
+package com.bungaebowling.server.applicant.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/posts/{postId}/applicants")
+public class ApplicantController {
+
+    @GetMapping
+    public ResponseEntity<?> getApplicants(){
+        return ResponseEntity.ok().body();
+    }
+
+    @PostMapping
+    public ResponseEntity<?> apply(){
+        return ResponseEntity.ok().body();
+    }
+
+    @PutMapping("/{applicantId}")
+    public ResponseEntity<?> accept(){
+        return ResponseEntity.ok().body();
+    }
+
+    @DeleteMapping("/{applicantId}")
+    public ResponseEntity<?> reject(){
+        return ResponseEntity.ok().body();
+    }
+}

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -19,31 +19,30 @@ public class ApplicantController {
     private final ApplicantService applicantService;
 
     @GetMapping
-    public ResponseEntity<?> getApplicants(@PathVariable Long postId,
-                                           @AuthenticationPrincipal CustomUserDetails userDetails,
-                                           CursorRequest cursorRequest){
+    public ResponseEntity<?> getApplicants(@PathVariable Long postId, CursorRequest cursorRequest,
+                                           @AuthenticationPrincipal CustomUserDetails userDetails){
         PageCursor<ApplicantResponse.GetApplicantsDto> getApplicantsDto = applicantService.getApplicants(userDetails.getId(), postId, cursorRequest);
         var response = ApiUtils.success(getApplicantsDto);
         return ResponseEntity.ok().body(response);
     }
 
     @PostMapping
-    public ResponseEntity<?> apply(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        applicantService.apply();
-        return ResponseEntity.ok().body();
+    public ResponseEntity<?> create(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        applicantService.create(userDetails.getId(), postId);
+        return ResponseEntity.ok(ApiUtils.success());
     }
 
     @PutMapping("/{applicantId}")
-    public ResponseEntity<?> accept(@PathVariable Long postId, @PathVariable Long applicantId,
+    public ResponseEntity<?> update(@PathVariable Long postId, @PathVariable Long applicantId,
                                     @AuthenticationPrincipal CustomUserDetails userDetails){
-        applicantService.accept();
-        return ResponseEntity.ok().body();
+        applicantService.update(userDetails.getId(), applicantId);
+        return ResponseEntity.ok(ApiUtils.success());
     }
 
     @DeleteMapping("/{applicantId}")
-    public ResponseEntity<?> reject(@PathVariable Long postId, @PathVariable Long applicantId,
+    public ResponseEntity<?> delete(@PathVariable Long postId, @PathVariable Long applicantId,
                                     @AuthenticationPrincipal CustomUserDetails userDetails){
-        applicantService.reject();
-        return ResponseEntity.ok().body();
+        applicantService.delete(userDetails.getId(), applicantId);
+        return ResponseEntity.ok(ApiUtils.success());
     }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -34,16 +34,14 @@ public class ApplicantController {
     }
 
     @PutMapping("/{applicantId}")
-    public ResponseEntity<?> update(@PathVariable Long postId, @PathVariable Long applicantId,
-                                    ApplicantRequest.UpdateDto requestDto,
+    public ResponseEntity<?> update(@PathVariable Long applicantId, ApplicantRequest.UpdateDto requestDto,
                                     @AuthenticationPrincipal CustomUserDetails userDetails){
         applicantService.update(userDetails.getId(), applicantId, requestDto);
         return ResponseEntity.ok(ApiUtils.success());
     }
 
     @DeleteMapping("/{applicantId}")
-    public ResponseEntity<?> delete(@PathVariable Long postId, @PathVariable Long applicantId,
-                                    @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<?> delete(@PathVariable Long applicantId, @AuthenticationPrincipal CustomUserDetails userDetails){
         applicantService.delete(userDetails.getId(), applicantId);
         return ResponseEntity.ok(ApiUtils.success());
     }

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -3,6 +3,7 @@ package com.bungaebowling.server.applicant.controller;
 import com.bungaebowling.server._core.security.CustomUserDetails;
 import com.bungaebowling.server._core.utils.ApiUtils;
 import com.bungaebowling.server._core.utils.cursor.CursorRequest;
+import com.bungaebowling.server._core.utils.cursor.PageCursor;
 import com.bungaebowling.server.applicant.dto.ApplicantResponse;
 import com.bungaebowling.server.applicant.service.ApplicantService;
 import lombok.RequiredArgsConstructor;
@@ -18,9 +19,10 @@ public class ApplicantController {
     private final ApplicantService applicantService;
 
     @GetMapping
-    public ResponseEntity<?> getApplicants(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails,
+    public ResponseEntity<?> getApplicants(@PathVariable Long postId,
+                                           @AuthenticationPrincipal CustomUserDetails userDetails,
                                            CursorRequest cursorRequest){
-        ApplicantResponse.GetApplicantsDto getApplicantsDto = applicantService.getApplicants(userDetails.getId(), postId, cursorRequest);
+        PageCursor<ApplicantResponse.GetApplicantsDto> getApplicantsDto = applicantService.getApplicants(userDetails.getId(), postId, cursorRequest);
         var response = ApiUtils.success(getApplicantsDto);
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -7,6 +7,7 @@ import com.bungaebowling.server._core.utils.cursor.PageCursor;
 import com.bungaebowling.server.applicant.dto.ApplicantRequest;
 import com.bungaebowling.server.applicant.dto.ApplicantResponse;
 import com.bungaebowling.server.applicant.service.ApplicantService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,26 +23,25 @@ public class ApplicantController {
     @GetMapping
     public ResponseEntity<?> getApplicants(@PathVariable Long postId, CursorRequest cursorRequest,
                                            @AuthenticationPrincipal CustomUserDetails userDetails){
-        PageCursor<ApplicantResponse.GetApplicantsDto> getApplicantsDto = applicantService.getApplicants(1L, postId, cursorRequest);
+        PageCursor<ApplicantResponse.GetApplicantsDto> getApplicantsDto = applicantService.getApplicants(userDetails.getId(), postId, cursorRequest);
         var response = ApiUtils.success(getApplicantsDto);
         return ResponseEntity.ok().body(response);
     }
 
     @PostMapping
     public ResponseEntity<?> create(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        applicantService.create(null, postId);
+        applicantService.create(userDetails.user(), postId);
         return ResponseEntity.ok(ApiUtils.success());
     }
 
     @PutMapping("/{applicantId}")
-    public ResponseEntity<?> accept(@PathVariable Long applicantId, @RequestBody ApplicantRequest.UpdateDto requestDto,
-                                    @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<?> accept(@PathVariable Long applicantId, @RequestBody @Valid ApplicantRequest.UpdateDto requestDto,){
         applicantService.accept(applicantId, requestDto);
         return ResponseEntity.ok(ApiUtils.success());
     }
 
     @DeleteMapping("/{applicantId}")
-    public ResponseEntity<?> reject(@PathVariable Long applicantId, @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<?> reject(@PathVariable Long applicantId){
         applicantService.reject(applicantId);
         return ResponseEntity.ok(ApiUtils.success());
     }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
@@ -1,4 +1,11 @@
 package com.bungaebowling.server.applicant.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public class ApplicantRequest {
+
+    public record UpdateDto(
+            @NotBlank
+            Boolean status
+    ){}
 }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
@@ -1,11 +1,11 @@
 package com.bungaebowling.server.applicant.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public class ApplicantRequest {
 
     public record UpdateDto(
-            @NotBlank
+            @NotNull
             Boolean status
     ){}
 }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
@@ -1,0 +1,4 @@
+package com.bungaebowling.server.applicant.dto;
+
+public class ApplicantRequest {
+}

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -1,4 +1,25 @@
 package com.bungaebowling.server.applicant.dto;
 
+import com.bungaebowling.server._core.utils.cursor.CursorRequest;
+import com.bungaebowling.server.applicant.Applicant;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ApplicantResponse {
+
+    public record GetApplicantsDto(
+            CursorRequest nextCursorRequest,
+            Integer applicantNumber,
+            List<ApplicantDto> applicants
+    ) {
+        public record ApplicantDto(
+                Long id,
+                String userName,
+                String profileImage,
+                Double rating
+        ) {
+
+        }
+    }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -1,10 +1,8 @@
 package com.bungaebowling.server.applicant.dto;
 
-import com.bungaebowling.server._core.utils.cursor.CursorRequest;
 import com.bungaebowling.server.applicant.Applicant;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ApplicantResponse {
 
@@ -15,8 +13,8 @@ public class ApplicantResponse {
         public static GetApplicantsDto mapToGetApplicantsDto(Integer applicantNumber, List<Applicant> applicants){
             return new GetApplicantsDto(applicantNumber, applicants.stream().map(applicant -> new ApplicantDto(
                     applicant.getId(),
-                    applicant.getUser().getName(),
-                    applicant.getUser().getImgUrl(),
+                    "이름", //applicant.getUser().getName(),
+                    "이미지 url", //applicant.getUser().getImgUrl(),
                     1.0 //UserRate 생성된 후 수정
             )).toList());
         }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -1,0 +1,4 @@
+package com.bungaebowling.server.applicant.dto;
+
+public class ApplicantResponse {
+}

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -13,8 +13,8 @@ public class ApplicantResponse {
         public static GetApplicantsDto mapToGetApplicantsDto(Integer applicantNumber, List<Applicant> applicants){
             return new GetApplicantsDto(applicantNumber, applicants.stream().map(applicant -> new ApplicantDto(
                     applicant.getId(),
-                    "이름", //applicant.getUser().getName(),
-                    "이미지 url", //applicant.getUser().getImgUrl(),
+                    applicant.getUser().getName(),
+                    applicant.getUser().getImgUrl(),
                     1.0 //UserRate 생성된 후 수정
             )).toList());
         }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -9,10 +9,18 @@ import java.util.stream.Collectors;
 public class ApplicantResponse {
 
     public record GetApplicantsDto(
-            CursorRequest nextCursorRequest,
             Integer applicantNumber,
             List<ApplicantDto> applicants
     ) {
+        public static GetApplicantsDto mapToGetApplicantsDto(Integer applicantNumber, List<Applicant> applicants){
+            return new GetApplicantsDto(applicantNumber, applicants.stream().map(applicant -> new ApplicantDto(
+                    applicant.getId(),
+                    applicant.getUser().getName(),
+                    applicant.getUser().getImgUrl(),
+                    1.0 //UserRate 생성된 후 수정)
+            )).collect(Collectors.toList()));
+        }
+
         public record ApplicantDto(
                 Long id,
                 String userName,

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -17,8 +17,8 @@ public class ApplicantResponse {
                     applicant.getId(),
                     applicant.getUser().getName(),
                     applicant.getUser().getImgUrl(),
-                    1.0 //UserRate 생성된 후 수정)
-            )).collect(Collectors.toList()));
+                    1.0 //UserRate 생성된 후 수정
+            )).toList());
         }
 
         public record ApplicantDto(

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -10,7 +10,7 @@ public class ApplicantResponse {
             Integer applicantNumber,
             List<ApplicantDto> applicants
     ) {
-        public static GetApplicantsDto mapToGetApplicantsDto(Integer applicantNumber, List<Applicant> applicants){
+        public static GetApplicantsDto of(Integer applicantNumber, List<Applicant> applicants){
             return new GetApplicantsDto(applicantNumber, applicants.stream().map(applicant -> new ApplicantDto(
                     applicant.getId(),
                     applicant.getUser().getName(),

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -15,7 +15,7 @@ public class ApplicantResponse {
                     applicant.getId(),
                     applicant.getUser().getName(),
                     applicant.getUser().getImgUrl(),
-                    1.0 //UserRate 생성된 후 수정
+                    1.0 //TODO: UserRate 생성된 후 수정
             )).toList());
         }
 

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -3,6 +3,7 @@ package com.bungaebowling.server.applicant.repository;
 import com.bungaebowling.server.applicant.Applicant;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -11,9 +12,13 @@ import java.util.List;
 @Repository
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
-    @Query("select a from Applicant a join fetch a.user u join fetch a.post p where u.id = :userId and p.id = :postId order by a.createdAt asc")
+    @Query("select a from Applicant a join a.user u join a.post p where u.id = :userId and p.id = :postId order by a.createdAt asc")
     List<Applicant> findApplicantByPostId(Pageable pageable, Long userId, Long postId);
 
-    @Query("select count(a) from Applicant a join fetch a.post p where p.id = :postId and a.status = true")
+    @Query("select count(a) from Applicant a join a.post p where p.id = :postId and a.status = true")
     int getApplicantNumber(Long postId);
+
+    @Modifying
+    @Query("update Applicant a SET a.status = :status where a.id = :applicantId")
+    void update(Long applicantId, Boolean status);
 }

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -24,7 +24,7 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     List<Applicant> findAllByUserIdAndPostIdLessThanOrderByIdDesc(@Param("key") Long key, @Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
 
     @Query("SELECT count(a) FROM Applicant a JOIN a.post p WHERE p.id = :postId AND a.status = true")
-    int getApplicantNumber(@Param("postId") Long postId);
+    int countByPostId(@Param("postId") Long postId);
 
     @Modifying
     @Query("UPDATE Applicant a SET a.status = :status WHERE a.id = :applicantId")

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -20,5 +20,5 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
     @Modifying
     @Query("update Applicant a SET a.status = :status where a.id = :applicantId")
-    void update(Long applicantId, Boolean status);
+    void updateStatus(Long applicantId, Boolean status);
 }

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -1,6 +1,7 @@
 package com.bungaebowling.server.applicant.repository;
 
 import com.bungaebowling.server.applicant.Applicant;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -10,8 +11,8 @@ import java.util.List;
 @Repository
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
-    @Query("select a from Applicant a join fetch a.user u join fetch a.post p where u.id = :userId and p.id = :postId")
-    List<Applicant> findApplicantByPostId(Long userId, Long postId);
+    @Query("select a from Applicant a join fetch a.user u join fetch a.post p where u.id = :userId and p.id = :postId order by a.createdAt asc")
+    List<Applicant> findApplicantByPostId(Pageable pageable, Long userId, Long postId);
 
     @Query("select count(a) from Applicant a join fetch a.post p where p.id = :postId and a.status = true")
     int getApplicantNumber(Long postId);

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -1,0 +1,4 @@
+package com.bungaebowling.server.applicant.repository;
+
+public interface ApplicantRepository {
+}

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -3,7 +3,6 @@ package com.bungaebowling.server.applicant.repository;
 import com.bungaebowling.server.applicant.Applicant;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -25,8 +24,4 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
     @Query("SELECT count(a) FROM Applicant a JOIN a.post p WHERE p.id = :postId AND a.status = true")
     int countByPostId(@Param("postId") Long postId);
-
-    @Modifying
-    @Query("UPDATE Applicant a SET a.status = :status WHERE a.id = :applicantId")
-    void updateStatus(@Param("applicantId") Long applicantId, @Param("status") Boolean status);
 }

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -12,8 +12,11 @@ import java.util.List;
 @Repository
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
-    @Query("select a from Applicant a join a.user u join a.post p where u.id = :userId and p.id = :postId order by a.createdAt asc")
-    List<Applicant> findApplicantByPostId(Pageable pageable, Long userId, Long postId);
+    List<Applicant> findAllByPostIdOrderByIdAsc(Long userId, Long postId);
+
+    List<Applicant> findAllByPostIdOrderByIdAsc(Pageable pageable, Long userId, Long postId);
+
+    List<Applicant> findAllByPostIdLessThanOrderByIdAsc(Pageable pageable, Long key, Long userId, Long postId);
 
     @Query("select count(a) from Applicant a join a.post p where p.id = :postId and a.status = true")
     int getApplicantNumber(Long postId);

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -14,16 +14,13 @@ import java.util.Optional;
 @Repository
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
-    //@Query("SELECT a FROM Applicant a JOIN a.user u JOIN a.post p WHERE u.id = :userId AND p.id = :postId")
-    @Query("SELECT a FROM Applicant a JOIN a.post p WHERE a.userId = :userId AND p.id = :postId")
+    @Query("SELECT a FROM Applicant a JOIN a.user u JOIN a.post p WHERE u.id = :userId AND p.id = :postId")
     Optional<Applicant> findByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
 
-    //@Query("SELECT a FROM Applicant a JOIN a.user u JOIN a.post p WHERE u.id = :userId AND p.id = :postId ORDER BY a.id DESC")
-    @Query("SELECT a FROM Applicant a JOIN a.post p WHERE a.userId = :userId AND p.id = :postId AND a.status = false ORDER BY a.id DESC")
+    @Query("SELECT a FROM Applicant a JOIN a.user u JOIN a.post p WHERE u.id = :userId AND p.id = :postId AND a.status = false ORDER BY a.id DESC")
     List<Applicant> findAllByUserIdAndPostIdOrderByIdDesc(@Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
 
-    //@Query("SELECT a FROM Applicant a JOIN a.user u JOIN a.post p WHERE u.id = :userId AND p.id = :postId AND a.id < :key ORDER BY a.id DESC")
-    @Query("SELECT a FROM Applicant a JOIN a.post p WHERE a.userId = :userId AND p.id = :postId AND a.id < :key AND a.status = false ORDER BY a.id DESC")
+    @Query("SELECT a FROM Applicant a JOIN a.user u JOIN a.post p WHERE u.id = :userId AND p.id = :postId AND a.id < :key AND a.status = false ORDER BY a.id DESC")
     List<Applicant> findAllByUserIdAndPostIdLessThanOrderByIdDesc(@Param("key") Long key, @Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
 
     @Query("SELECT count(a) FROM Applicant a JOIN a.post p WHERE p.id = :postId AND a.status = true")

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -5,23 +5,31 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
-    List<Applicant> findAllByPostIdOrderByIdAsc(Long userId, Long postId);
+    //@Query("SELECT a FROM Applicant a JOIN a.user u JOIN a.post p WHERE u.id = :userId AND p.id = :postId")
+    @Query("SELECT a FROM Applicant a JOIN a.post p WHERE a.userId = :userId AND p.id = :postId")
+    Optional<Applicant> findByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
 
-    List<Applicant> findAllByPostIdOrderByIdAsc(Pageable pageable, Long userId, Long postId);
+    //@Query("SELECT a FROM Applicant a JOIN a.user u JOIN a.post p WHERE u.id = :userId AND p.id = :postId ORDER BY a.id DESC")
+    @Query("SELECT a FROM Applicant a JOIN a.post p WHERE a.userId = :userId AND p.id = :postId AND a.status = false ORDER BY a.id DESC")
+    List<Applicant> findAllByUserIdAndPostIdOrderByIdDesc(@Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
 
-    List<Applicant> findAllByPostIdLessThanOrderByIdAsc(Pageable pageable, Long key, Long userId, Long postId);
+    //@Query("SELECT a FROM Applicant a JOIN a.user u JOIN a.post p WHERE u.id = :userId AND p.id = :postId AND a.id < :key ORDER BY a.id DESC")
+    @Query("SELECT a FROM Applicant a JOIN a.post p WHERE a.userId = :userId AND p.id = :postId AND a.id < :key AND a.status = false ORDER BY a.id DESC")
+    List<Applicant> findAllByUserIdAndPostIdLessThanOrderByIdDesc(@Param("key") Long key, @Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
 
-    @Query("select count(a) from Applicant a join a.post p where p.id = :postId and a.status = true")
-    int getApplicantNumber(Long postId);
+    @Query("SELECT count(a) FROM Applicant a JOIN a.post p WHERE p.id = :postId AND a.status = true")
+    int getApplicantNumber(@Param("postId") Long postId);
 
     @Modifying
-    @Query("update Applicant a SET a.status = :status where a.id = :applicantId")
-    void updateStatus(Long applicantId, Boolean status);
+    @Query("UPDATE Applicant a SET a.status = :status WHERE a.id = :applicantId")
+    void updateStatus(@Param("applicantId") Long applicantId, @Param("status") Boolean status);
 }

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -1,4 +1,18 @@
 package com.bungaebowling.server.applicant.repository;
 
-public interface ApplicantRepository {
+import com.bungaebowling.server.applicant.Applicant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
+
+    @Query("select a from Applicant a join fetch a.user u join fetch a.post p where u.id = :userId and p.id = :postId")
+    List<Applicant> findApplicantByPostId(Long userId, Long postId);
+
+    @Query("select count(a) from Applicant a join fetch a.post p where p.id = :postId and a.status = true")
+    int getApplicantNumber(Long postId);
 }

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -1,15 +1,17 @@
 package com.bungaebowling.server.applicant.service;
 
 import com.bungaebowling.server._core.utils.cursor.CursorRequest;
+import com.bungaebowling.server._core.utils.cursor.PageCursor;
 import com.bungaebowling.server.applicant.Applicant;
 import com.bungaebowling.server.applicant.dto.ApplicantResponse;
 import com.bungaebowling.server.applicant.repository.ApplicantRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -18,16 +20,12 @@ public class ApplicantService {
 
     private final ApplicantRepository applicantRepository;
 
-    public ApplicantResponse.GetApplicantsDto getApplicants(Long userId, Long postId, CursorRequest cursorRequest){
+    public PageCursor<ApplicantResponse.GetApplicantsDto> getApplicants(Long userId, Long postId, CursorRequest cursorRequest){
+        Pageable pageable = PageRequest.of(0, cursorRequest.size());
         int applicantNumber = applicantRepository.getApplicantNumber(postId);
-        List<Applicant> applicants = applicantRepository.findApplicantByPostId(userId, postId);
-        List<ApplicantResponse.GetApplicantsDto.ApplicantDto> applicantDtos = applicants.stream().map(applicant -> new ApplicantResponse.GetApplicantsDto.ApplicantDto(
-                applicant.getId(),
-                applicant.getUser().getName(),
-                applicant.getUser().getImgUrl(),
-                1.0 //UserRate 생성된 후 수정
-        )).collect(Collectors.toList());
-        return new ApplicantResponse.GetApplicantsDto(cursorRequest, applicantNumber, applicantDtos);
+        List<Applicant> applicants = applicantRepository.findApplicantByPostId(pageable, userId, postId);
+        Long key = 1L;
+        return new PageCursor<>(cursorRequest.next(key), ApplicantResponse.GetApplicantsDto.mapToGetApplicantsDto(applicantNumber, applicants));
     }
 
     public void apply(){

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -1,10 +1,14 @@
 package com.bungaebowling.server.applicant.service;
 
+import com.bungaebowling.server._core.errors.exception.client.Exception404;
 import com.bungaebowling.server._core.utils.cursor.CursorRequest;
 import com.bungaebowling.server._core.utils.cursor.PageCursor;
 import com.bungaebowling.server.applicant.Applicant;
 import com.bungaebowling.server.applicant.dto.ApplicantResponse;
 import com.bungaebowling.server.applicant.repository.ApplicantRepository;
+import com.bungaebowling.server.post.Post;
+import com.bungaebowling.server.post.repository.PostRepository;
+import com.bungaebowling.server.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +23,7 @@ import java.util.List;
 public class ApplicantService {
 
     private final ApplicantRepository applicantRepository;
+    private final PostRepository postRepository;
 
     public PageCursor<ApplicantResponse.GetApplicantsDto> getApplicants(Long userId, Long postId, CursorRequest cursorRequest){
         Pageable pageable = PageRequest.of(0, cursorRequest.size());
@@ -28,15 +33,23 @@ public class ApplicantService {
         return new PageCursor<>(cursorRequest.next(key), ApplicantResponse.GetApplicantsDto.mapToGetApplicantsDto(applicantNumber, applicants));
     }
 
-    public void apply(){
+    @Transactional
+    public void create(Long userId, Long postId){
+        User user = null; //user repository 추가되면 수정 예정
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new Exception404("존재하지 않는 모집글입니다.")
+        );
+        Applicant applicant = Applicant.builder().user(user).post(post).build();
+        applicantRepository.save(applicant);
+    }
+
+    @Transactional
+    public void update(Long userId, Long applicantId){
 
     }
 
-    public void accept(){
-
-    }
-
-    public void reject(){
+    @Transactional
+    public void delete(Long userId, Long applicantId){
 
     }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -4,6 +4,7 @@ import com.bungaebowling.server._core.errors.exception.client.Exception404;
 import com.bungaebowling.server._core.utils.cursor.CursorRequest;
 import com.bungaebowling.server._core.utils.cursor.PageCursor;
 import com.bungaebowling.server.applicant.Applicant;
+import com.bungaebowling.server.applicant.dto.ApplicantRequest;
 import com.bungaebowling.server.applicant.dto.ApplicantResponse;
 import com.bungaebowling.server.applicant.repository.ApplicantRepository;
 import com.bungaebowling.server.post.Post;
@@ -44,12 +45,18 @@ public class ApplicantService {
     }
 
     @Transactional
-    public void update(Long userId, Long applicantId){
-
+    public void update(Long userId, Long applicantId, ApplicantRequest.UpdateDto requestDto){
+        Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(
+                () -> new Exception404("존재하지 않는 신청입니다.")
+        );
+        applicantRepository.update(applicant.getId(), requestDto.status());
     }
 
     @Transactional
     public void delete(Long userId, Long applicantId){
-
+        Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(
+                () -> new Exception404("존재하지 않는 신청입니다.")
+        );
+        applicantRepository.deleteById(applicant.getId());
     }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -11,6 +11,7 @@ import com.bungaebowling.server.applicant.repository.ApplicantRepository;
 import com.bungaebowling.server.post.Post;
 import com.bungaebowling.server.post.repository.PostRepository;
 import com.bungaebowling.server.user.User;
+import com.bungaebowling.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -55,19 +56,22 @@ public class ApplicantService {
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new Exception404("존재하지 않는 모집글입니다.")
         );
+        
+        //게시글 작성자 신청 금지
 
         //신청 중복 확인
         applicantRepository.findByUserIdAndPostId(1L, postId).ifPresent(applicant -> {
             throw new Exception400("이미 신청된 사용자입니다.");
         });
 
-        Applicant applicant = Applicant.builder().userId(1L).post(post).build();
-        //Applicant applicant = Applicant.builder().user(user).post(post).build();
+        Applicant applicant = Applicant.builder().user(user).post(post).build();
         applicantRepository.save(applicant);
     }
 
     @Transactional
     public void accept(Long applicantId, ApplicantRequest.UpdateDto requestDto){
+        //게시글 작성자만 수락 가능
+
         Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(
                 () -> new Exception404("존재하지 않는 신청입니다.")
         );

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -1,4 +1,44 @@
 package com.bungaebowling.server.applicant.service;
 
+import com.bungaebowling.server._core.utils.cursor.CursorRequest;
+import com.bungaebowling.server.applicant.Applicant;
+import com.bungaebowling.server.applicant.dto.ApplicantResponse;
+import com.bungaebowling.server.applicant.repository.ApplicantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
 public class ApplicantService {
+
+    private final ApplicantRepository applicantRepository;
+
+    public ApplicantResponse.GetApplicantsDto getApplicants(Long userId, Long postId, CursorRequest cursorRequest){
+        int applicantNumber = applicantRepository.getApplicantNumber(postId);
+        List<Applicant> applicants = applicantRepository.findApplicantByPostId(userId, postId);
+        List<ApplicantResponse.GetApplicantsDto.ApplicantDto> applicantDtos = applicants.stream().map(applicant -> new ApplicantResponse.GetApplicantsDto.ApplicantDto(
+                applicant.getId(),
+                applicant.getUser().getName(),
+                applicant.getUser().getImgUrl(),
+                1.0 //UserRate 생성된 후 수정
+        )).collect(Collectors.toList());
+        return new ApplicantResponse.GetApplicantsDto(cursorRequest, applicantNumber, applicantDtos);
+    }
+
+    public void apply(){
+
+    }
+
+    public void accept(){
+
+    }
+
+    public void reject(){
+
+    }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -1,0 +1,4 @@
+package com.bungaebowling.server.applicant.service;
+
+public class ApplicantService {
+}

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -35,7 +35,7 @@ public class ApplicantService {
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new Exception404("존재하지 않는 모집글입니다.")
         );
-        int applicantNumber = applicantRepository.getApplicantNumber(post.getId());
+        int applicantNumber = applicantRepository.countByPostId(post.getId());
         List<Applicant> applicants = loadApplicants(userId, cursorRequest, post);
         Long lastKey = applicants.isEmpty() ? CursorRequest.NONE_KEY : applicants.get(applicants.size() - 1).getId();
         return new PageCursor<>(cursorRequest.next(lastKey), ApplicantResponse.GetApplicantsDto.of(applicantNumber, applicants));

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -80,7 +80,7 @@ public class ApplicantService {
         Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(
                 () -> new Exception404("존재하지 않는 신청입니다.")
         );
-        applicantRepository.updateStatus(applicant.getId(), requestDto.status());
+        applicant.updateStatus(requestDto.status());
     }
 
     @Transactional

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -38,7 +38,7 @@ public class ApplicantService {
         int applicantNumber = applicantRepository.getApplicantNumber(post.getId());
         List<Applicant> applicants = loadApplicants(userId, cursorRequest, post);
         Long lastKey = applicants.isEmpty() ? CursorRequest.NONE_KEY : applicants.get(applicants.size() - 1).getId();
-        return new PageCursor<>(cursorRequest.next(lastKey), ApplicantResponse.GetApplicantsDto.mapToGetApplicantsDto(applicantNumber, applicants));
+        return new PageCursor<>(cursorRequest.next(lastKey), ApplicantResponse.GetApplicantsDto.of(applicantNumber, applicants));
     }
 
     private List<Applicant> loadApplicants(Long userId, CursorRequest cursorRequest, Post post) {

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -28,6 +28,7 @@ public class ApplicantService {
     public static final int DEFAULT_SIZE = 20;
 
     private final ApplicantRepository applicantRepository;
+    private final UserRepository userRepository;
     private final PostRepository postRepository;
 
     public PageCursor<ApplicantResponse.GetApplicantsDto> getApplicants(Long userId, Long postId, CursorRequest cursorRequest){
@@ -52,15 +53,19 @@ public class ApplicantService {
     }
 
     @Transactional
-    public void create(User user, Long postId){
+    public void create(Long userId, Long postId){
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new Exception404("존재하지 않는 사용자입니다.")
+        );
+
         Post post = postRepository.findById(postId).orElseThrow(
                 () -> new Exception404("존재하지 않는 모집글입니다.")
         );
         
-        //게시글 작성자 신청 금지
+        //TODO: 게시글 작성자 신청 금지
 
         //신청 중복 확인
-        applicantRepository.findByUserIdAndPostId(1L, postId).ifPresent(applicant -> {
+        applicantRepository.findByUserIdAndPostId(userId, postId).ifPresent(applicant -> {
             throw new Exception400("이미 신청된 사용자입니다.");
         });
 
@@ -70,7 +75,7 @@ public class ApplicantService {
 
     @Transactional
     public void accept(Long applicantId, ApplicantRequest.UpdateDto requestDto){
-        //게시글 작성자만 수락 가능
+        //TODO: 게시글 작성자만 수락 가능
 
         Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(
                 () -> new Exception404("존재하지 않는 신청입니다.")

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -34,19 +34,19 @@ public class ApplicantService {
     public PageCursor<ApplicantResponse.GetApplicantsDto> getApplicants(Long userId, Long postId, CursorRequest cursorRequest){
         Post post = getPost(postId);
         int applicantNumber = applicantRepository.countByPostId(post.getId());
-        List<Applicant> applicants = loadApplicants(userId, cursorRequest, post);
+        List<Applicant> applicants = loadApplicants(userId, cursorRequest, post.getId());
         Long lastKey = applicants.isEmpty() ? CursorRequest.NONE_KEY : applicants.get(applicants.size() - 1).getId();
         return new PageCursor<>(cursorRequest.next(lastKey), ApplicantResponse.GetApplicantsDto.of(applicantNumber, applicants));
     }
 
-    private List<Applicant> loadApplicants(Long userId, CursorRequest cursorRequest, Post post) {
+    private List<Applicant> loadApplicants(Long userId, CursorRequest cursorRequest, Long postId) {
         int size = cursorRequest.hasSize() ? cursorRequest.size() : DEFAULT_SIZE;
         Pageable pageable = PageRequest.of(0, size);
 
         if(!cursorRequest.hasKey()){
-            return applicantRepository.findAllByUserIdAndPostIdOrderByIdDesc(userId, post.getId(), pageable);
+            return applicantRepository.findAllByUserIdAndPostIdOrderByIdDesc(userId, postId, pageable);
         }else{
-            return applicantRepository.findAllByUserIdAndPostIdLessThanOrderByIdDesc(cursorRequest.key(), userId, post.getId(), pageable);
+            return applicantRepository.findAllByUserIdAndPostIdLessThanOrderByIdDesc(cursorRequest.key(), userId, postId, pageable);
         }
     }
 

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -49,7 +49,7 @@ public class ApplicantService {
         Applicant applicant = applicantRepository.findById(applicantId).orElseThrow(
                 () -> new Exception404("존재하지 않는 신청입니다.")
         );
-        applicantRepository.update(applicant.getId(), requestDto.status());
+        applicantRepository.updateStatus(applicant.getId(), requestDto.status());
     }
 
     @Transactional

--- a/src/main/java/com/bungaebowling/server/userRate/UserRate.java
+++ b/src/main/java/com/bungaebowling/server/userRate/UserRate.java
@@ -1,0 +1,46 @@
+package com.bungaebowling.server.userRate;
+
+import com.bungaebowling.server.applicant.Applicant;
+import com.bungaebowling.server.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name="user_rate_tb")
+public class UserRate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int starCount;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "applicant_id", referencedColumnName = "id")
+    private Applicant applicant;
+
+    @ColumnDefault("now()")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UserRate(Long id, int starCount, User user, Applicant applicant, LocalDateTime createdAt) {
+        this.id = id;
+        this.starCount = starCount;
+        this.user = user;
+        this.applicant = applicant;
+        this.createdAt = createdAt;
+    }
+}


### PR DESCRIPTION
## Summary
신청 API를 구현했습니다. 
- 신청자 목록 조회
- 모집글에 대한 신청
- 신청 수락
- 신청 취소 또는 거절

## Description

### 신청자 목록 조회
- 신청자 목록은 20개씩 applicant.id 내림차순 기준으로 가져오도록 설정했습니다. 커서 size가 없으면 디폴트 값 20을 넣어줬습니다. 커서 key가 있으면 키보다 작은 데이터를 보내고, 키가 없으면 가장 마지막 id부터 가져옵니다.
- 연관 엔티티 user, post가 검색 조건에는 필요하지만 실제 데이터는 사용되지 않으므로 join fetch가 아닌 join을 사용했습니다.
- 평점 기능이 구현되지 않아 rating은 모두 1.0으로 전달됩니다. 

### 모집글에 대한 신청
- user.id, post.id에 대한 유니크 조건을 추가했지만 신청 중복 확인 로직도 추가했습니다. 

### 테스트
```
INSERT INTO post_tb (title) VALUES ('제목');
```
```
@Entity
@Getter
@DynamicInsert
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Table(name = "post_tb")
public class Post {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(length = 100)
    private String title;
}

```

위의 코드처럼 적당히 post에 넣고 유니크 조건이랑 신청 중복 부분 주석 처리하면 한 사용자마다 post 요청 여러 번 할 수 있어서 페이징 결과 확인하실 수 있습니다! 
## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #13
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->