### PR TITLE
인증 이메일 발송을 통한 이메일 검사 구현

### DIFF
--- a/src/main/java/com/bungaebowling/server/_core/config/MailConfig.java
+++ b/src/main/java/com/bungaebowling/server/_core/config/MailConfig.java
@@ -1,0 +1,42 @@
+package com.bungaebowling.server._core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    @Value("${mail.host}")
+    private String host;
+    @Value("${mail.port}")
+    private int port;
+    @Value("${mail.username}")
+    private String username;
+    @Value("${mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost(host);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.smtp.auth", "true");
+        properties.setProperty("mail.smtp.starttls.enable", "true");
+        return properties;
+    }
+}

--- a/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
@@ -68,6 +68,17 @@ public class JwtProvider {
                 .sign(Algorithm.HMAC512(secret));
     }
 
+    public static String createEmailVerification(User user) {
+        LocalDateTime now = LocalDateTime.now();
+
+        LocalDateTime expired = now.plusDays(1); // 하루동안 유효
+        return JWT.create()
+                .withSubject(user.getId().toString())
+                .withClaim("type", TYPE_EMAIL_VERIFICATION)
+                .withExpiresAt(Timestamp.valueOf(expired))
+                .sign(Algorithm.HMAC512(secret));
+    }
+
     public static DecodedJWT verify(String jwt, String type) {
         try {
             DecodedJWT decodedJwt = JWT.require(Algorithm.HMAC512(secret)).build()

--- a/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
@@ -83,7 +83,8 @@ public class SecurityConfig {
                         .requestMatchers(new AntPathRequestMatcher("/api/posts/**", "GET")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/messages/**", "GET"),
                                 new AntPathRequestMatcher("/api/users/mine"),
-                                new AntPathRequestMatcher("/api/logout")).hasAnyRole("USER", "PENDING")
+                                new AntPathRequestMatcher("/api/logout"),
+                                new AntPathRequestMatcher("/api/email-verification")).hasAnyRole("USER", "PENDING")
                         .requestMatchers(new AntPathRequestMatcher("/api/posts/**"),
                                 new AntPathRequestMatcher("/api/applicants/**"),
                                 new AntPathRequestMatcher( "/api/messages/**")).hasRole("USER")

--- a/src/main/java/com/bungaebowling/server/user/User.java
+++ b/src/main/java/com/bungaebowling/server/user/User.java
@@ -52,4 +52,8 @@ public class User {
         this.role = role;
         this.createdAt = createdAt;
     }
+
+    public void updateRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -83,6 +83,12 @@ public class UserController {
                 .body(response);
     }
 
+    @PostMapping("/email-verification")
+    public ResponseEntity<?> sendVerification(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.sendVerificationMail(userDetails.getId());
+        return ResponseEntity.ok().body(ApiUtils.success());
+    }
+
     @GetMapping("/users")
     public ResponseEntity<?> getUsers() {
         CursorRequest cursorRequest = new CursorRequest(1L, 20);

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -89,6 +89,12 @@ public class UserController {
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 
+    @PostMapping("/email-confirm")
+    public ResponseEntity<?> confirmEmail(@RequestBody UserRequest.ConfirmEmailDto requestDto, Errors errors) {
+        userService.confirmEmail(requestDto);
+        return ResponseEntity.ok().body(ApiUtils.success());
+    }
+
     @GetMapping("/users")
     public ResponseEntity<?> getUsers() {
         CursorRequest cursorRequest = new CursorRequest(1L, 20);

--- a/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
@@ -36,4 +36,9 @@ public class UserRequest {
                     .build();
         }
     }
+
+    public record ConfirmEmailDto(
+            @NotEmpty
+            String token
+    ) {}
 }

--- a/src/main/resources/application-private.yml.example
+++ b/src/main/resources/application-private.yml.example
@@ -1,5 +1,6 @@
 bungaebowling:
   secret: bungaebowling
+  domain: http://localhost:3000
 mail:
   host: smtp.gmail.com
   port: 587

--- a/src/main/resources/application-private.yml.example
+++ b/src/main/resources/application-private.yml.example
@@ -1,2 +1,7 @@
 bungaebowling:
   secret: bungaebowling
+mail:
+  host: smtp.gmail.com
+  port: 587
+  username:
+  password:


### PR DESCRIPTION
## Summary

인증 이메일 발송 및 이메일 인증으로 권한 증가 구현완료했습니다.

## Description

따로 메일 서버 만들기엔 아직 서버도 구축이 안되어 있어서 gmail을 활용하여 구현했습니다.

application-private.yml에 내용이 추가되었습니다. 여기에 gmail과 앱 비밀번호를 작성해야합니다.

gmail username은 bungaebowling55@gmail.com 이고 앱 비밀번호는 문의 주시면 알려드리겠습니다.

![image](https://github.com/Step3-kakao-tech-campus/Team3_BE/assets/84557643/31da98d4-3185-4b19-a5bd-f0ae9bb150c7)

메일의 형태는 아직 다듬지 않아 단순히 링크만 전달하며 접속 할 프론트 화면이 구현되어 있어야합니다.

링크는 http://localhost:3000/email-verification?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIyIiwidHlwZSI6ImVtYWlsLXZlcmlmaWNhdGlvbiIsImV4cCI6MTY5NjEwMDgzNn0.MJMb2Q61AWtpzWs4Bw51Pd1OVBjLxQynub2lECfsYYaC2IhAjwUEJVmPHqng_YA-XSzq6eADof-k_nbDozvp7Q

이 형태이며 token 의 값을 이용해 /api/email-confirm으로 요청 시 user 권한 부여 일어나게 됩니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #20 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->