### PR TITLE
신청자 목록 조회 응답 바디 수정 및 기타 버그 수정

### DIFF
--- a/src/main/java/com/bungaebowling/server/applicant/Applicant.java
+++ b/src/main/java/com/bungaebowling/server/applicant/Applicant.java
@@ -27,11 +27,11 @@ public class Applicant {
     @ColumnDefault("false")
     private Boolean status;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", referencedColumnName = "id")
     private Post post;
 

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -2,6 +2,7 @@ package com.bungaebowling.server.applicant.dto;
 
 import com.bungaebowling.server._core.utils.CursorRequest;
 import com.bungaebowling.server.applicant.Applicant;
+import com.bungaebowling.server.user.User;
 
 import java.util.List;
 
@@ -9,24 +10,48 @@ public class ApplicantResponse {
 
     public record GetApplicantsDto(
             CursorRequest nextCursorRequest,
-            Integer applicantNumber,
+            Long participantNumber,
+            Long currentNumber,
             List<ApplicantDto> applicants
     ) {
-        public static GetApplicantsDto of(CursorRequest nextCursorRequest, Integer applicantNumber, List<Applicant> applicants){
-            return new GetApplicantsDto(nextCursorRequest, applicantNumber, applicants.stream().map(applicant -> new ApplicantDto(
-                    applicant.getId(),
-                    applicant.getUser().getName(),
-                    applicant.getUser().getImgUrl(),
-                    1.0 //TODO: UserRate 생성된 후 수정
-            )).toList());
+        public static GetApplicantsDto of(CursorRequest nextCursorRequest, Long participantNumber, Long currentNumber, List<Applicant> applicants){
+            return new GetApplicantsDto(
+                    nextCursorRequest,
+                    participantNumber,
+                    currentNumber,
+                    applicants.stream().map(ApplicantDto::new).toList()
+            );
         }
 
         public record ApplicantDto(
                 Long id,
-                String userName,
-                String profileImage,
-                Double rating
+                UserDto user,
+                Boolean status
         ) {
+
+            public ApplicantDto(Applicant applicant) {
+                this(
+                        applicant.getId(),
+                        new UserDto(applicant.getUser()),
+                        applicant.getStatus()
+                );
+            }
+
+            public record UserDto(
+                    Long id,
+                    String name,
+                    String profileImage,
+                    Double rating
+            ) {
+                public UserDto(User user) {
+                    this(
+                            user.getId(),
+                            user.getName(),
+                            user.getImgUrl(),
+                            0.0  //TODO: UserRate 생성된 후 수정
+                    );
+                }
+            }
 
         }
     }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -3,6 +3,7 @@ package com.bungaebowling.server.applicant.dto;
 import com.bungaebowling.server._core.utils.CursorRequest;
 import com.bungaebowling.server.applicant.Applicant;
 import com.bungaebowling.server.user.User;
+import com.bungaebowling.server.user.rate.UserRate;
 
 import java.util.List;
 
@@ -48,7 +49,9 @@ public class ApplicantResponse {
                             user.getId(),
                             user.getName(),
                             user.getImgUrl(),
-                            0.0  //TODO: UserRate 생성된 후 수정
+                            user.getUserRates().stream()
+                                    .mapToInt(UserRate::getStarCount)
+                                    .average().orElse(0.0)
                     );
                 }
             }

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -16,10 +16,10 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     @Query("SELECT a FROM Applicant a WHERE a.user.id = :userId AND a.post.id = :postId")
     Optional<Applicant> findByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
 
-    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND a.status = false ORDER BY a.id DESC")
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId ORDER BY a.id DESC")
     List<Applicant> findAllByPostIdOrderByIdDesc(@Param("postId") Long postId, Pageable pageable);
 
-    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND a.id < :key AND a.status = false ORDER BY a.id DESC")
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND a.id < :key ORDER BY a.id DESC")
     List<Applicant> findAllByPostIdLessThanOrderByIdDesc(@Param("key") Long key, @Param("postId") Long postId, Pageable pageable);
 
     @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId AND a.status = true")

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -16,11 +16,11 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     @Query("SELECT a FROM Applicant a WHERE a.user.id = :userId AND a.post.id = :postId")
     Optional<Applicant> findByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
 
-    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE u.id = :userId AND a.post.id = :postId AND a.status = false ORDER BY a.id DESC")
-    List<Applicant> findAllByUserIdAndPostIdOrderByIdDesc(@Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND a.status = false ORDER BY a.id DESC")
+    List<Applicant> findAllByPostIdOrderByIdDesc(@Param("postId") Long postId, Pageable pageable);
 
-    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE u.id = :userId AND a.post.id = :postId AND a.id < :key AND a.status = false ORDER BY a.id DESC")
-    List<Applicant> findAllByUserIdAndPostIdLessThanOrderByIdDesc(@Param("key") Long key, @Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND a.id < :key AND a.status = false ORDER BY a.id DESC")
+    List<Applicant> findAllByPostIdLessThanOrderByIdDesc(@Param("key") Long key, @Param("postId") Long postId, Pageable pageable);
 
     @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId AND a.status = true")
     Long countByPostIdAndIsStatusTrue(@Param("postId") Long postId);

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -23,7 +23,10 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     List<Applicant> findAllByUserIdAndPostIdLessThanOrderByIdDesc(@Param("key") Long key, @Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
 
     @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId AND a.status = true")
-    int countByPostId(@Param("postId") Long postId);
+    Long countByPostIdAndIsStatusTrue(@Param("postId") Long postId);
+
+    @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId")
+    Long countByPostId(@Param("postId") Long postId);
 
     @Query("SELECT a FROM Applicant a JOIN FETCH a.post p WHERE a.id = :id")
     Optional<Applicant> findByIdJoinFetchPost(@Param("id") Long id);

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -34,6 +34,10 @@ public class ApplicantService {
 
     public ApplicantResponse.GetApplicantsDto getApplicants(Long userId, Long postId, CursorRequest cursorRequest){
         Post post = getPost(postId);
+
+        if (!Objects.equals(post.getUser().getId(), userId))
+            throw new Exception403("자신의 모집글이 아닙니다.");
+
         Long participantNumber = applicantRepository.countByPostId(post.getId());
         Long currentNumber = applicantRepository.countByPostIdAndIsStatusTrue(post.getId());
         List<Applicant> applicants = loadApplicants(cursorRequest, post.getId());

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -36,7 +36,7 @@ public class ApplicantService {
         Post post = getPost(postId);
         Long participantNumber = applicantRepository.countByPostId(post.getId());
         Long currentNumber = applicantRepository.countByPostIdAndIsStatusTrue(post.getId());
-        List<Applicant> applicants = loadApplicants(userId, cursorRequest, post.getId());
+        List<Applicant> applicants = loadApplicants(cursorRequest, post.getId());
         Long lastKey = applicants.isEmpty() ? CursorRequest.NONE_KEY : applicants.get(applicants.size() - 1).getId();
 
         return ApplicantResponse.GetApplicantsDto.of(
@@ -46,14 +46,14 @@ public class ApplicantService {
                 applicants);
     }
 
-    private List<Applicant> loadApplicants(Long userId, CursorRequest cursorRequest, Long postId) {
+    private List<Applicant> loadApplicants(CursorRequest cursorRequest, Long postId) {
         int size = cursorRequest.hasSize() ? cursorRequest.size() : DEFAULT_SIZE;
         Pageable pageable = PageRequest.of(0, size);
 
         if(!cursorRequest.hasKey()){
-            return applicantRepository.findAllByUserIdAndPostIdOrderByIdDesc(userId, postId, pageable);
+            return applicantRepository.findAllByPostIdOrderByIdDesc(postId, pageable);
         }else{
-            return applicantRepository.findAllByUserIdAndPostIdLessThanOrderByIdDesc(cursorRequest.key(), userId, postId, pageable);
+            return applicantRepository.findAllByPostIdLessThanOrderByIdDesc(cursorRequest.key(), postId, pageable);
         }
     }
 

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -34,10 +34,16 @@ public class ApplicantService {
 
     public ApplicantResponse.GetApplicantsDto getApplicants(Long userId, Long postId, CursorRequest cursorRequest){
         Post post = getPost(postId);
-        int applicantNumber = applicantRepository.countByPostId(post.getId());
+        Long participantNumber = applicantRepository.countByPostId(post.getId());
+        Long currentNumber = applicantRepository.countByPostIdAndIsStatusTrue(post.getId());
         List<Applicant> applicants = loadApplicants(userId, cursorRequest, post.getId());
         Long lastKey = applicants.isEmpty() ? CursorRequest.NONE_KEY : applicants.get(applicants.size() - 1).getId();
-        return ApplicantResponse.GetApplicantsDto.of(cursorRequest.next(lastKey, DEFAULT_SIZE), applicantNumber, applicants);
+
+        return ApplicantResponse.GetApplicantsDto.of(
+                cursorRequest.next(lastKey, DEFAULT_SIZE),
+                participantNumber,
+                currentNumber,
+                applicants);
     }
 
     private List<Applicant> loadApplicants(Long userId, CursorRequest cursorRequest, Long postId) {

--- a/src/main/java/com/bungaebowling/server/post/Post.java
+++ b/src/main/java/com/bungaebowling/server/post/Post.java
@@ -15,8 +15,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static jakarta.persistence.FetchType.LAZY;
-
 @Entity
 @Getter
 @DynamicInsert
@@ -30,11 +28,11 @@ public class Post {
     @Column(length = 100, nullable = false)
     private String title;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", updatable = false) // updatable = false -> 작성자 변경 불가
     private User user;
 
-    @ManyToOne(fetch = LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "district_id")
     private District district;
 

--- a/src/main/java/com/bungaebowling/server/post/controller/PostController.java
+++ b/src/main/java/com/bungaebowling/server/post/controller/PostController.java
@@ -153,7 +153,7 @@ public class PostController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .location(URI.create("/api/posts/" + postId))
-                .body(ApiUtils.success());
+                .body(ApiUtils.success(HttpStatus.CREATED));
     }
 
     @PutMapping("/{postId}")

--- a/src/main/java/com/bungaebowling/server/score/Score.java
+++ b/src/main/java/com/bungaebowling/server/score/Score.java
@@ -1,4 +1,4 @@
-package com.bungaebowling.server.Score;
+package com.bungaebowling.server.score;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/bungaebowling/server/user/User.java
+++ b/src/main/java/com/bungaebowling/server/user/User.java
@@ -1,12 +1,15 @@
 package com.bungaebowling.server.user;
 
 import com.bungaebowling.server.city.country.district.District;
+import com.bungaebowling.server.user.rate.UserRate;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -40,6 +43,9 @@ public class User {
 
     @ColumnDefault("now()")
     private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private final List<UserRate> userRates = new ArrayList<>();
 
     @Builder
     public User(Long id, String name, String email, String password, District district, String imgUrl, Role role, LocalDateTime createdAt) {

--- a/src/main/java/com/bungaebowling/server/user/rate/UserRate.java
+++ b/src/main/java/com/bungaebowling/server/user/rate/UserRate.java
@@ -1,4 +1,4 @@
-package com.bungaebowling.server.userRate;
+package com.bungaebowling.server.user.rate;
 
 import com.bungaebowling.server.applicant.Applicant;
 import com.bungaebowling.server.user.User;

--- a/src/main/java/com/bungaebowling/server/user/rate/UserRate.java
+++ b/src/main/java/com/bungaebowling/server/user/rate/UserRate.java
@@ -22,21 +22,23 @@ public class UserRate {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private int starCount;
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "applicant_id", referencedColumnName = "id")
     private Applicant applicant;
+
+
+    @Column(nullable = false)
+    private Integer starCount;
 
     @ColumnDefault("now()")
     private LocalDateTime createdAt;
 
     @Builder
-    public UserRate(Long id, int starCount, User user, Applicant applicant, LocalDateTime createdAt) {
+    public UserRate(Long id, User user, Applicant applicant, Integer starCount, LocalDateTime createdAt) {
         this.id = id;
         this.starCount = starCount;
         this.user = user;

--- a/src/main/java/com/bungaebowling/server/user/rate/repository/UserRateRepository.java
+++ b/src/main/java/com/bungaebowling/server/user/rate/repository/UserRateRepository.java
@@ -1,0 +1,7 @@
+package com.bungaebowling.server.user.rate.repository;
+
+import com.bungaebowling.server.user.rate.UserRate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRateRepository extends JpaRepository<UserRate, Long> {
+}


### PR DESCRIPTION
## Summary

신청자 목록 조회 api의 응답 body를 수정하였습니다. 또한, rating을 계산해서 같이 주도록 변경하였으며, 기타 자잘한 버그들을 수정하였습니다.

## Description

- ApplicantResponse.GetApplicantsDto에 필요한 정보가 추가로 존재하여 개선하였습니다.
  - 유저 ID를 함께 줍니다.
  - 수락된 사람 수 / 전체 신청 수를 줍니다.
- select 문에서 로그인한 유저의 id가 where 절 안에 들어가는 문제를 수정하였습니다.
- 자신의 모집글인 경우만 신청자 목록을 확인할 수 있도록 권한 확인을 추하였습니다.
- 패키지명에 대문자가 작성되어있는 문제를 해결하였습니다.(score와 userRate)
- User안에 OneToMany를 추가하여 간단하게 rating 정보를 가져올 수 있도록 하였습니다.
  - 하지만 이는 N + 1 문제가 남아있습니다.
  - 신청자목록을 조회한 후 한번에 20개씩 조회한다고 하면 20개의 userRate에 접근하는 쿼리가 발생하게 됩니다.
  - 구현의 용이성을 위해 일단은 이렇게 작성하고 넘어갑니다.
- ManyToOne에 FetchType.LAZY가 안적혀있는 문제를 해결했습니다.
  - 이로 인해 쓸모없는 테이블까지 전부 Join되어 호출되고 있었습니다.
  - OneToMany의 경우 기본이 LAZY fetch여서 추가하지 않았습니다.
- 모집글 작성 시 status는 201을 주는데 response body 내부에는 200으로 주던 문제를 해결했습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #21 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->