### PR TITLE
댓글 api 구현 완료

### DIFF
--- a/src/main/java/com/bungaebowling/server/_core/errors/GlobalExceptionHandler.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/GlobalExceptionHandler.java
@@ -7,11 +7,13 @@ import com.bungaebowling.server._core.errors.exception.client.Exception403;
 import com.bungaebowling.server._core.errors.exception.client.Exception404;
 import com.bungaebowling.server._core.errors.exception.server.Exception500;
 import com.bungaebowling.server._core.utils.ApiUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
@@ -21,6 +23,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> unknownServerError(Exception e) {
+        log.error("unknown 에러 발생", e);
         var status = HttpStatus.INTERNAL_SERVER_ERROR;
         var response = ApiUtils.error(e.getMessage(), status);
         return ResponseEntity.status(status).body(response);

--- a/src/main/java/com/bungaebowling/server/comment/Comment.java
+++ b/src/main/java/com/bungaebowling/server/comment/Comment.java
@@ -58,4 +58,9 @@ public class Comment {
         this.editedAt = editedAt;
         this.createdAt = createdAt;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+        this.editedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/bungaebowling/server/comment/Comment.java
+++ b/src/main/java/com/bungaebowling/server/comment/Comment.java
@@ -63,4 +63,9 @@ public class Comment {
         this.content = content;
         this.editedAt = LocalDateTime.now();
     }
+
+    public void delete() {
+        this.content = "삭제된 댓글입니다.";
+        this.user = null;
+    }
 }

--- a/src/main/java/com/bungaebowling/server/comment/Comment.java
+++ b/src/main/java/com/bungaebowling/server/comment/Comment.java
@@ -1,0 +1,61 @@
+package com.bungaebowling.server.comment;
+
+import com.bungaebowling.server.post.Post;
+import com.bungaebowling.server.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "comment_tb")
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "edited_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    @ColumnDefault(value = "now()")
+    private LocalDateTime editedAt;
+
+    @Column(name = "created_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    @ColumnDefault(value = "now()")
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Comment(Long id, Post post, User user, Comment parent, String content, LocalDateTime editedAt, LocalDateTime createdAt) {
+        this.id = id;
+        this.post = post;
+        this.user = user;
+        this.parent = parent;
+        this.content = content;
+        this.editedAt = editedAt;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
+++ b/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
@@ -55,4 +55,15 @@ public class CommentController {
         return ResponseEntity.created(new URI("/api/posts/" + postId + "/comments/" + savedId))
                 .body(ApiUtils.success(201));
     }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<?> edit(@PathVariable Long postId,
+                                  @PathVariable Long commentId,
+                                  @AuthenticationPrincipal CustomUserDetails userDetails,
+                                  @RequestBody @Valid CommentRequest.EditDto requestDto,
+                                  Errors errors) {
+        commentService.edit(commentId, userDetails.getId(), requestDto);
+
+        return ResponseEntity.ok().body(ApiUtils.success());
+    }
 }

--- a/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
+++ b/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
@@ -97,4 +97,16 @@ public class CommentController {
         return ResponseEntity.created(new URI("/api/posts/" + postId + "/comments/" + savedId))
                 .body(ApiUtils.success(201));
     }
+
+    @PostMapping("/{commentId}/reply")
+    public ResponseEntity<?> createReply(@PathVariable Long postId,
+                                         @PathVariable Long commentId,
+                                         @AuthenticationPrincipal CustomUserDetails userDetails,
+                                         @RequestBody @Valid CommentRequest.CreateDto requestDto,
+                                         Errors errors) throws URISyntaxException {
+
+        var savedId = commentService.createReply(userDetails.getId(), postId, commentId, requestDto);
+        return ResponseEntity.created(new URI("/api/posts/" + postId + "/comments/" + savedId))
+                .body(ApiUtils.success(201));
+    }
 }

--- a/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
+++ b/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
@@ -15,10 +15,10 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/posts")
+@RequestMapping("/api/posts/{postId}/comments")
 public class CommentController {
 
-    @GetMapping("/{postId}/comments")
+    @GetMapping
     public ResponseEntity<?> getComments() {
         CursorRequest cursorRequest = new CursorRequest(1L, 20);
         List<CommentResponse.GetCommentsDto.CommentDto> commentsDtos = new ArrayList<>();

--- a/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
+++ b/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
@@ -28,7 +28,7 @@ public class CommentController {
 
     @GetMapping
     public ResponseEntity<?> getComments(@PathVariable Long postId, CursorRequest cursorRequest) {
-        CommentResponse.GetCommentsDto responseDto = commentService.getComments(cursorRequest, postId);
+        var responseDto = commentService.getComments(cursorRequest, postId);
 
         return ResponseEntity.ok().body(ApiUtils.success(responseDto));
     }
@@ -39,9 +39,8 @@ public class CommentController {
                                     @RequestBody @Valid CommentRequest.CreateDto requestDto,
                                     Errors errors) throws URISyntaxException {
 
-        var savedId = commentService.create(userDetails.getId(), postId, requestDto);
-        return ResponseEntity.created(new URI("/api/posts/" + postId + "/comments/" + savedId))
-                .body(ApiUtils.success(201));
+        var responseDto = commentService.create(userDetails.getId(), postId, requestDto);
+        return ResponseEntity.ok().body(ApiUtils.success(responseDto));
     }
 
     @PostMapping("/{commentId}/reply")
@@ -51,9 +50,8 @@ public class CommentController {
                                          @RequestBody @Valid CommentRequest.CreateDto requestDto,
                                          Errors errors) throws URISyntaxException {
 
-        var savedId = commentService.createReply(userDetails.getId(), postId, commentId, requestDto);
-        return ResponseEntity.created(new URI("/api/posts/" + postId + "/comments/" + savedId))
-                .body(ApiUtils.success(201));
+        var responseDto = commentService.createReply(userDetails.getId(), postId, commentId, requestDto);
+        return ResponseEntity.ok().body(ApiUtils.success(responseDto));
     }
 
     @PutMapping("/{commentId}")

--- a/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
+++ b/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
@@ -1,14 +1,20 @@
 package com.bungaebowling.server.comment.controller;
 
+import com.bungaebowling.server._core.security.CustomUserDetails;
 import com.bungaebowling.server._core.utils.ApiUtils;
 import com.bungaebowling.server._core.utils.CursorRequest;
+import com.bungaebowling.server.comment.dto.CommentRequest;
 import com.bungaebowling.server.comment.dto.CommentResponse;
+import com.bungaebowling.server.comment.service.CommentService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +23,8 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/posts/{postId}/comments")
 public class CommentController {
+
+    final private CommentService commentService;
 
     @GetMapping
     public ResponseEntity<?> getComments() {
@@ -77,5 +85,16 @@ public class CommentController {
 
         var response = ApiUtils.success(getCommentsDto);
         return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<?> create(@PathVariable Long postId,
+                                    @AuthenticationPrincipal CustomUserDetails userDetails,
+                                    @RequestBody @Valid CommentRequest.CreateDto requestDto,
+                                    Errors errors) throws URISyntaxException {
+
+        var savedId = commentService.create(userDetails.getId(), postId, requestDto);
+        return ResponseEntity.created(new URI("/api/posts/" + postId + "/comments/" + savedId))
+                .body(ApiUtils.success(201));
     }
 }

--- a/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
+++ b/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
@@ -27,64 +27,10 @@ public class CommentController {
     final private CommentService commentService;
 
     @GetMapping
-    public ResponseEntity<?> getComments() {
-        CursorRequest cursorRequest = new CursorRequest(1L, 20);
-        List<CommentResponse.GetCommentsDto.CommentDto> commentsDtos = new ArrayList<>();
-        var commentDto1 = new CommentResponse.GetCommentsDto.CommentDto(
-                1L,
-                1L,
-                "볼링조아",
-                null,
-                "저 참여하고 싶습니다.",
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                List.of(
-                        new CommentResponse.GetCommentsDto.CommentDto.ChildCommentDto(
-                                2L,
-                                2L,
-                                "김볼링",
-                                null,
-                                "몇명이신가요?",
-                                LocalDateTime.now(),
-                                LocalDateTime.now()
-                        ),
-                        new CommentResponse.GetCommentsDto.CommentDto.ChildCommentDto(
-                                3L,
-                                1L,
-                                "볼링조아",
-                                null,
-                                "2인 참여 가능할까요?",
-                                LocalDateTime.now(),
-                                LocalDateTime.now()
-                        ),
-                        new CommentResponse.GetCommentsDto.CommentDto.ChildCommentDto(
-                                4L,
-                                3L,
-                                "거터처리반",
-                                null,
-                                "동반 1인입니다!",
-                                LocalDateTime.now(),
-                                LocalDateTime.now()
-                        )
-                )
-        );
-        commentsDtos.add(commentDto1);
-        var commentDto2 = new CommentResponse.GetCommentsDto.CommentDto(
-                4L,
-                3L,
-                "거터처리반",
-                null,
-                "동반 1인입니다!",
-                LocalDateTime.now(),
-                LocalDateTime.now(),
-                List.of()
-        );
-        commentsDtos.add(commentDto2);
+    public ResponseEntity<?> getComments(@PathVariable Long postId, CursorRequest cursorRequest) {
+        CommentResponse.GetCommentsDto responseDto = commentService.getComments(cursorRequest, postId);
 
-        var getCommentsDto = new CommentResponse.GetCommentsDto(cursorRequest, commentsDtos);
-
-        var response = ApiUtils.success(getCommentsDto);
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.ok().body(ApiUtils.success(responseDto));
     }
 
     @PostMapping

--- a/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
+++ b/src/main/java/com/bungaebowling/server/comment/controller/CommentController.java
@@ -66,4 +66,13 @@ public class CommentController {
 
         return ResponseEntity.ok().body(ApiUtils.success());
     }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<?> delete(@PathVariable Long postId,
+                                    @PathVariable Long commentId,
+                                    @AuthenticationPrincipal CustomUserDetails userDetails) {
+        commentService.delete(commentId, userDetails.getId());
+
+        return ResponseEntity.ok().body(ApiUtils.success());
+    }
 }

--- a/src/main/java/com/bungaebowling/server/comment/dto/CommentRequest.java
+++ b/src/main/java/com/bungaebowling/server/comment/dto/CommentRequest.java
@@ -1,0 +1,4 @@
+package com.bungaebowling.server.comment.dto;
+
+public class CommentRequest {
+}

--- a/src/main/java/com/bungaebowling/server/comment/dto/CommentRequest.java
+++ b/src/main/java/com/bungaebowling/server/comment/dto/CommentRequest.java
@@ -28,4 +28,9 @@ public class CommentRequest {
                     .build();
         }
     }
+
+    public record EditDto(
+            @NotBlank(message = "내용은 필수 입력 값 입니다.")
+            String content
+    ){ }
 }

--- a/src/main/java/com/bungaebowling/server/comment/dto/CommentRequest.java
+++ b/src/main/java/com/bungaebowling/server/comment/dto/CommentRequest.java
@@ -1,4 +1,22 @@
 package com.bungaebowling.server.comment.dto;
 
+import com.bungaebowling.server.comment.Comment;
+import com.bungaebowling.server.post.Post;
+import com.bungaebowling.server.user.User;
+import jakarta.validation.constraints.NotBlank;
+
 public class CommentRequest {
+
+    public record CreateDto(
+            @NotBlank(message = "내용은 필수 입력 값 입니다.")
+            String content
+    ){
+        public Comment toEntity(User user, Post post) {
+            return Comment.builder()
+                    .post(post)
+                    .user(user)
+                    .content(content)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/bungaebowling/server/comment/dto/CommentRequest.java
+++ b/src/main/java/com/bungaebowling/server/comment/dto/CommentRequest.java
@@ -11,10 +11,19 @@ public class CommentRequest {
             @NotBlank(message = "내용은 필수 입력 값 입니다.")
             String content
     ){
-        public Comment toEntity(User user, Post post) {
+        public Comment createComment(User user, Post post) {
             return Comment.builder()
                     .post(post)
                     .user(user)
+                    .content(content)
+                    .build();
+        }
+
+        public Comment createReply(User user, Post post, Comment parent) {
+            return Comment.builder()
+                    .post(post)
+                    .user(user)
+                    .parent(parent)
                     .content(content)
                     .build();
         }

--- a/src/main/java/com/bungaebowling/server/comment/dto/CommentResponse.java
+++ b/src/main/java/com/bungaebowling/server/comment/dto/CommentResponse.java
@@ -2,9 +2,12 @@ package com.bungaebowling.server.comment.dto;
 
 import com.bungaebowling.server._core.utils.CursorRequest;
 import com.bungaebowling.server.comment.Comment;
+import com.bungaebowling.server.user.User;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 public class CommentResponse {
@@ -36,9 +39,9 @@ public class CommentResponse {
             public CommentDto(Comment comment, List<Comment> childComments) {
                 this(
                         comment.getId(),
-                        comment.getUser().getId(),
-                        comment.getUser().getName(),
-                        comment.getUser().getImgUrl(),
+                        Optional.ofNullable(comment.getUser()).map(User::getId).orElse(null),
+                        Optional.ofNullable(comment.getUser()).map(User::getName).orElse(null),
+                        Optional.ofNullable(comment.getUser()).map(User::getImgUrl).orElse(null),
                         comment.getContent(),
                         comment.getCreatedAt(),
                         comment.getEditedAt(),
@@ -58,9 +61,9 @@ public class CommentResponse {
                 public ChildCommentDto(Comment childComment) {
                     this(
                             childComment.getId(),
-                            childComment.getUser().getId(),
-                            childComment.getUser().getName(),
-                            childComment.getUser().getImgUrl(),
+                            Optional.ofNullable(childComment.getUser()).map(User::getId).orElse(null),
+                            Optional.ofNullable(childComment.getUser()).map(User::getName).orElse(null),
+                            Optional.ofNullable(childComment.getUser()).map(User::getImgUrl).orElse(null),
                             childComment.getContent(),
                             childComment.getCreatedAt(),
                             childComment.getEditedAt()

--- a/src/main/java/com/bungaebowling/server/comment/dto/CommentResponse.java
+++ b/src/main/java/com/bungaebowling/server/comment/dto/CommentResponse.java
@@ -1,9 +1,11 @@
 package com.bungaebowling.server.comment.dto;
 
 import com.bungaebowling.server._core.utils.CursorRequest;
+import com.bungaebowling.server.comment.Comment;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.IntStream;
 
 public class CommentResponse {
 
@@ -11,6 +13,15 @@ public class CommentResponse {
             CursorRequest nextCursorRequest,
             List<CommentDto> comments
     ) {
+
+        public static GetCommentsDto of(CursorRequest nextCursorRequest, List<Comment> comments, List<List<Comment>> childComments) {
+            return new GetCommentsDto(
+                    nextCursorRequest,
+                    IntStream.range(0, comments.size())
+                            .mapToObj(index -> new CommentDto(comments.get(index), childComments.get(index)))
+                            .toList()
+                    );
+        }
         public record CommentDto(
                 Long id,
                 Long userId,
@@ -21,6 +32,19 @@ public class CommentResponse {
                 LocalDateTime editedAt,
                 List<ChildCommentDto> childComments
         ) {
+
+            public CommentDto(Comment comment, List<Comment> childComments) {
+                this(
+                        comment.getId(),
+                        comment.getUser().getId(),
+                        comment.getUser().getName(),
+                        comment.getUser().getImgUrl(),
+                        comment.getContent(),
+                        comment.getCreatedAt(),
+                        comment.getEditedAt(),
+                        childComments.stream().map(ChildCommentDto::new).toList()
+                );
+            }
             public record ChildCommentDto(
                     Long id,
                     Long userId,
@@ -31,6 +55,17 @@ public class CommentResponse {
                     LocalDateTime editedAt
             ) {
 
+                public ChildCommentDto(Comment childComment) {
+                    this(
+                            childComment.getId(),
+                            childComment.getUser().getId(),
+                            childComment.getUser().getName(),
+                            childComment.getUser().getImgUrl(),
+                            childComment.getContent(),
+                            childComment.getCreatedAt(),
+                            childComment.getEditedAt()
+                    );
+                }
             }
         }
 

--- a/src/main/java/com/bungaebowling/server/comment/dto/CommentResponse.java
+++ b/src/main/java/com/bungaebowling/server/comment/dto/CommentResponse.java
@@ -70,4 +70,6 @@ public class CommentResponse {
         }
 
     }
+
+    public record CreateDto(Long id) { }
 }

--- a/src/main/java/com/bungaebowling/server/comment/repository/CommentRepository.java
+++ b/src/main/java/com/bungaebowling/server/comment/repository/CommentRepository.java
@@ -2,9 +2,32 @@ package com.bungaebowling.server.comment.repository;
 
 
 import com.bungaebowling.server.comment.Comment;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c " +
+            "FROM Comment c JOIN FETCH c.user u " +
+            "WHERE c.post.id = :postId AND c.parent = null " +
+            "ORDER BY c.id")
+    List<Comment> findAllByPostIdAndIsParentNullOrderById(@Param("postId") Long postId, Pageable pageable);
+
+    @Query("SELECT c " +
+            "FROM Comment c JOIN FETCH c.user u " +
+            "WHERE c.parent.id = :parentId " +
+            "ORDER BY c.id")
+    List<Comment> findAllByParentId(@Param("parentId") Long parentId);
+
+    @Query("SELECT c " +
+            "FROM Comment c JOIN FETCH c.user u " +
+            "WHERE c.post.id = :postId AND c.parent = null AND c.id > :key " +
+            "ORDER BY c.id")
+    List<Comment> findAllByPostIdAndIsParentNullAndIdGreaterThanOrderById(@Param("postId") Long postId, @Param("key") Long key, Pageable pageable);
 }

--- a/src/main/java/com/bungaebowling/server/comment/repository/CommentRepository.java
+++ b/src/main/java/com/bungaebowling/server/comment/repository/CommentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -30,4 +31,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "WHERE c.post.id = :postId AND c.parent = null AND c.id > :key " +
             "ORDER BY c.id")
     List<Comment> findAllByPostIdAndIsParentNullAndIdGreaterThanOrderById(@Param("postId") Long postId, @Param("key") Long key, Pageable pageable);
+
+    @Query("SELECT c FROM Comment c WHERE c.id = :id AND c.post.id = :postId AND c.parent = null")
+    Optional<Comment> findByIdAndPostIdAndParentNull(@Param("id") Long id, @Param("postId") Long postId);
 }

--- a/src/main/java/com/bungaebowling/server/comment/repository/CommentRepository.java
+++ b/src/main/java/com/bungaebowling/server/comment/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.bungaebowling.server.comment.repository;
+
+
+import com.bungaebowling.server.comment.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/bungaebowling/server/comment/repository/CommentRepository.java
+++ b/src/main/java/com/bungaebowling/server/comment/repository/CommentRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT c " +
-            "FROM Comment c JOIN FETCH c.user u " +
+            "FROM Comment c LEFT JOIN FETCH c.user u " +
             "WHERE c.post.id = :postId AND c.parent = null " +
             "ORDER BY c.id")
     List<Comment> findAllByPostIdAndIsParentNullOrderById(@Param("postId") Long postId, Pageable pageable);
@@ -27,7 +27,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByParentId(@Param("parentId") Long parentId);
 
     @Query("SELECT c " +
-            "FROM Comment c JOIN FETCH c.user u " +
+            "FROM Comment c LEFT JOIN FETCH c.user u " +
             "WHERE c.post.id = :postId AND c.parent = null AND c.id > :key " +
             "ORDER BY c.id")
     List<Comment> findAllByPostIdAndIsParentNullAndIdGreaterThanOrderById(@Param("postId") Long postId, @Param("key") Long key, Pageable pageable);

--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.bungaebowling.server.comment.service;
 
 
+import com.bungaebowling.server._core.errors.exception.client.Exception400;
 import com.bungaebowling.server._core.errors.exception.client.Exception403;
 import com.bungaebowling.server._core.errors.exception.client.Exception404;
 import com.bungaebowling.server._core.utils.CursorRequest;
@@ -56,23 +57,25 @@ public class CommentService {
     }
 
     @Transactional
-    public Long create(Long userId, Long postId, CommentRequest.CreateDto requestDto) {
+    public CommentResponse.CreateDto create(Long userId, Long postId, CommentRequest.CreateDto requestDto) {
         var user = userRepository.findById(userId).orElseThrow(() -> new Exception404("존재하지 않는 유저의 접근입니다."));
         var post = postRepository.findById(postId).orElseThrow(() -> new Exception404("존재하지 않는 모집글입니다."));
         var comment = requestDto.createComment(user, post);
 
-        return commentRepository.save(comment).getId();
+        var savedComment = commentRepository.save(comment);
+        return new CommentResponse.CreateDto(savedComment.getId());
     }
 
     @Transactional
-    public Long createReply(Long userId, Long postId, Long parentId, CommentRequest.CreateDto requestDto) {
+    public CommentResponse.CreateDto createReply(Long userId, Long postId, Long parentId, CommentRequest.CreateDto requestDto) {
         var user = userRepository.findById(userId).orElseThrow(() -> new Exception404("존재하지 않는 유저의 접근입니다."));
         var post = postRepository.findById(postId).orElseThrow(() -> new Exception404("존재하지 않는 모집글입니다."));
         var parent = commentRepository.findByIdAndPostIdAndParentNull(parentId, postId).orElseThrow(() -> new Exception400("대댓글을 작성할 수 없는 댓글입니다."));
 
         var comment = requestDto.createReply(user, post, parent);
 
-        return commentRepository.save(comment).getId();
+        var savedComment = commentRepository.save(comment);
+        return new CommentResponse.CreateDto(savedComment.getId());
     }
 
     @Transactional

--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -1,0 +1,11 @@
+package com.bungaebowling.server.comment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+}

--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -99,6 +99,6 @@ public class CommentService {
             throw new Exception403("본인의 댓글만 삭제 가능합니다.");
         }
 
-        commentRepository.delete(comment);
+        comment.delete();
     }
 }

--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -86,4 +86,16 @@ public class CommentService {
 
         comment.updateContent(requestDto.content());
     }
+
+    @Transactional
+    public void delete(Long commentId, Long userId) {
+        var user = userRepository.findById(userId).orElseThrow(() -> new Exception404("존재하지 않는 유저의 접근입니다."));
+        var comment = commentRepository.findById(commentId).orElseThrow(() -> new Exception404("존재하지 않는 댓글입니다."));
+
+        if (!Objects.equals(comment.getUser().getId(), user.getId())) {
+            throw new Exception403("본인의 댓글만 삭제 가능합니다.");
+        }
+
+        commentRepository.delete(comment);
+    }
 }

--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -68,7 +68,7 @@ public class CommentService {
     public Long createReply(Long userId, Long postId, Long parentId, CommentRequest.CreateDto requestDto) {
         var user = userRepository.findById(userId).orElseThrow(() -> new Exception404("존재하지 않는 유저의 접근입니다."));
         var post = postRepository.findById(postId).orElseThrow(() -> new Exception404("존재하지 않는 모집글입니다."));
-        var parent = commentRepository.findById(parentId).orElseThrow(() -> new Exception404("존재하지 않는 부모 댓글입니다."));
+        var parent = commentRepository.findByIdAndPostIdAndParentNull(parentId, postId).orElseThrow(() -> new Exception400("대댓글을 작성할 수 없는 댓글입니다."));
 
         var comment = requestDto.createReply(user, post, parent);
 

--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -1,5 +1,10 @@
 package com.bungaebowling.server.comment.service;
 
+import com.bungaebowling.server._core.errors.exception.client.Exception404;
+import com.bungaebowling.server.comment.dto.CommentRequest;
+import com.bungaebowling.server.comment.repository.CommentRepository;
+import com.bungaebowling.server.post.repository.PostRepository;
+import com.bungaebowling.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +13,19 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class CommentService {
+
+    final private UserRepository userRepository;
+
+    final private PostRepository postRepository;
+
+    final private CommentRepository commentRepository;
+
+    @Transactional
+    public Long create(Long userId, Long postId, CommentRequest.CreateDto requestDto) {
+        var user = userRepository.findById(userId).orElseThrow(() -> new Exception404("존재하지 않는 유저의 접근입니다."));
+        var post = postRepository.findById(postId).orElseThrow(() -> new Exception404("존재하지 않는 모집글입니다."));
+        var comment = requestDto.toEntity(user, post);
+
+        return commentRepository.save(comment).getId();
+    }
 }

--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.bungaebowling.server.comment.service;
 
 
+import com.bungaebowling.server._core.errors.exception.client.Exception403;
 import com.bungaebowling.server._core.errors.exception.client.Exception404;
 import com.bungaebowling.server._core.utils.CursorRequest;
 import com.bungaebowling.server.comment.Comment;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -71,5 +73,17 @@ public class CommentService {
         var comment = requestDto.createReply(user, post, parent);
 
         return commentRepository.save(comment).getId();
+    }
+
+    @Transactional
+    public void edit(Long commentId, Long userId, CommentRequest.EditDto requestDto) {
+        var user = userRepository.findById(userId).orElseThrow(() -> new Exception404("존재하지 않는 유저의 접근입니다."));
+        var comment = commentRepository.findById(commentId).orElseThrow(() -> new Exception404("존재하지 않는 댓글입니다."));
+
+        if (!Objects.equals(comment.getUser().getId(), user.getId())) {
+            throw new Exception403("본인의 댓글만 수정 가능합니다.");
+        }
+
+        comment.updateContent(requestDto.content());
     }
 }

--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -24,7 +24,18 @@ public class CommentService {
     public Long create(Long userId, Long postId, CommentRequest.CreateDto requestDto) {
         var user = userRepository.findById(userId).orElseThrow(() -> new Exception404("존재하지 않는 유저의 접근입니다."));
         var post = postRepository.findById(postId).orElseThrow(() -> new Exception404("존재하지 않는 모집글입니다."));
-        var comment = requestDto.toEntity(user, post);
+        var comment = requestDto.createComment(user, post);
+
+        return commentRepository.save(comment).getId();
+    }
+
+    @Transactional
+    public Long createReply(Long userId, Long postId, Long parentId, CommentRequest.CreateDto requestDto) {
+        var user = userRepository.findById(userId).orElseThrow(() -> new Exception404("존재하지 않는 유저의 접근입니다."));
+        var post = postRepository.findById(postId).orElseThrow(() -> new Exception404("존재하지 않는 모집글입니다."));
+        var parent = commentRepository.findById(parentId).orElseThrow(() -> new Exception404("존재하지 않는 부모 댓글입니다."));
+
+        var comment = requestDto.createReply(user, post, parent);
 
         return commentRepository.save(comment).getId();
     }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4734,4 +4734,12 @@ VALUES
 
 -- 비밀번호는 test12!@
 INSERT INTO user_tb (name, email, password, district_id, role)
-VALUES ('김볼링', 'test@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
+VALUES ('김볼링', 'test@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('볼링볼링', 'test1@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
+
+INSERT INTO post_tb (title, user_id, district_id, start_time, due_time, content)
+VALUES ('불금 볼링 점수 내기 하실 분~', 1, 1, '2023-12-01', '2023-11-29', '볼링 점수 내기합시다.');
+
+INSERT INTO comment_tb (post_id, user_id, parent_id, content)
+VALUES (1, 2, null, '저 해도 되나요?'),
+       (1, 1, 1, '신청해주세요~');

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -31,7 +31,7 @@ CREATE TABLE comment_tb
     post_id    BIGINT NOT NULL,
     user_id    BIGINT,
     parent_id  BIGINT,
-    contentT   TEXT,
+    content    TEXT,
     edited_at  TIMESTAMP DEFAULT now(),
     created_at TIMESTAMP DEFAULT now()
 );


### PR DESCRIPTION
## Summary

댓글 api 구현 완료 하였습니다. 구현을 하며 더미 유저, 모집글, 댓글들을 살짝 추가하였습니다.(data.sql)

댓글의 경우는 회의의 결과에 따라 처음부터 created가 아닌 200 status를 주며 id를 리턴하도록 구현하였습니다.

또한 개발 과정에서 디버깅의 용이성을 위해 unkown Error에 대해 stackTrace를 출력하도록 ExceptionHandler에 추가해두었습니다.


## Description

- 댓글 테이블 선언에서 contentT로 잘못적혀있는 부분을 수정하며 서버의 mysql에도 오류 수정 반영하였습니다.
- 댓글 생성 api를 구현완료하였습니다.
- 대댓글 생성 api를 구현완료하였습니다.
- 댓글 조회 api를 구현 완료하였습니다.
  - 모집글의 경우, 최근에 쓴 글이 최상위로 가지만, 댓글은 최근에 쓴 댓글이 최하위로 가게 됩니다.
  - 삭제된 댓글에 대댓글이 있는 경우만, "삭제된 댓글입니다"/ 유저id null로 돌려줍니다.
  - 그외, 대댓글이 없는 삭제된 댓글과 대댓글이 삭제된 경우의 댓글은 responseBody에 포함되어 내려가지 않습니다.
  - size=20으로 요청이 왔다고 가정했을때, 대댓글이없는 삭제된 댓글이 5개 함께 db에서 조회된 경우 15개의 최상위 댓글만이 response로 돌아가게됩니다.
  - 삭제된 댓글들로 인한 통일되지 않은 응답 개수 문제는,
    - 프론트의 구현이 무한 스크롤로 이루어질 것입니다.
    - 따라서 적은 개수가 응답되어도 자동으로 다음 key로 요청이 일어나 사용자 경험에 큰 영향을 주지 않습니다.
    - 그렇기 때문에 무시해도 될 것 같아 이렇게 구현하였습니다.
- 댓글 수정 api를 구현 완료하였습니다.
- 댓글 삭제 api를 구현 완료하였습니다.
  - 대댓글을 가지고 있는 댓글을 삭제 할 수 있으므로 삭제 시, user를 null로 변경하며 content를 '삭제된 댓글입니다'로 변경합니다.
  - user가 null이 될 수 있으므로 responseDto 만드는 과정에 null 체크를 추가하였습니다.(유저 이름, 유저 프로필 이미지)

---

추가

- 테스트 편하게 하기 위해 data.sql에 더미 데이터를 추가하였습니다.
  - 더미 유저, 볼링볼링(test1@test.com / test12!@) 계정(user 권한)을 추가하였습니다.
  - 더미 모집글을 추가하였습니다.
  - 해당 더미 모집글에 더미 댓글들을 추가하였습니다.
- global exception handler를 통해 디버깅하기 쉽도록, unkown error의 경우 stackTrace를 출력하도록 하였습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #30 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->