### PR TITLE
서버 타임존 KST 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     container_name: mysql
     ports:
       - 3307:3306
+    environment:
+      - TZ=Asia/Seoul
     env_file: .mysql_env
     volumes:
       - /opt/mysql:/var/lib/mysql

--- a/src/main/java/com/bungaebowling/server/ServerApplication.java
+++ b/src/main/java/com/bungaebowling/server/ServerApplication.java
@@ -1,10 +1,18 @@
 package com.bungaebowling.server;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class ServerApplication {
+
+	@PostConstruct
+	void started() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(ServerApplication.class, args);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,6 +30,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  jackson:
+    time-zone: Asia/Seoul
 
 logging:
   level:

--- a/src/main/resources/application-product.yml
+++ b/src/main/resources/application-product.yml
@@ -25,6 +25,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  jackson:
+    time-zone: Asia/Seoul
 
 logging:
   level:


### PR DESCRIPTION
## Summary

서버 timezone을 맞췄습니다. 통신은 전부 KST 한국 시간으로 이루어 집니다.

## Description

[노션 서버 타임존 설정](https://www.notion.so/f00649087a574c3499bb5956e89aaee1) 에서 전체 과정을 볼 수 있습니다.

서버 및 MySQL, Spring boot의 시간대를 전부 KST(Asia/Seoul)로 변경하였습니다.

자바스크립트 테스트에서 Date 객체 직렬화 시 자동으로 UST로 변경되는 점을 확인하였고, 프론트에 요청하여 직접 "2023-10-06T22:10:00" `YYYY-MM-DDTHH:MM:SS` 형식으로 요청해달라고 전달하였습니다.

직접 문자열로 변환한 결과, 정상 작동한다는 결과를 프론트로부터 받았습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #29 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->