### PR TITLE
신청 상태 조회 api에 applicant id 추가

### DIFF
--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -54,12 +54,12 @@ public class ApplicantResponse {
                     );
                 }
             }
-
         }
     }
 
     public record CheckStatusDto(
-            Boolean isApplied, //신청됨
-            Boolean isAccepted //수락됨
+            Long applicantId,
+            Boolean isApplied, //신청 여부
+            Boolean isAccepted //수락 여부
     ) {}
 }

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -16,11 +16,11 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     @Query("SELECT a FROM Applicant a WHERE a.user.id = :userId AND a.post.id = :postId")
     Optional<Applicant> findByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
 
-    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId ORDER BY a.id DESC")
-    List<Applicant> findAllByPostIdOrderByIdDesc(@Param("postId") Long postId, Pageable pageable);
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND u.id != :userId ORDER BY a.id DESC")
+    List<Applicant> findAllByPostIdAndUserIdNotOrderByIdDesc(@Param("postId") Long postId, @Param("userId") Long userId, Pageable pageable);
 
-    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND a.id < :key ORDER BY a.id DESC")
-    List<Applicant> findAllByPostIdLessThanOrderByIdDesc(@Param("key") Long key, @Param("postId") Long postId, Pageable pageable);
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND u.id != :userId AND a.id < :key ORDER BY a.id DESC")
+    List<Applicant> findAllByPostIdAndUserIdNotLessThanOrderByIdDesc(@Param("key") Long key, @Param("postId") Long postId, @Param("userId") Long userId, Pageable pageable);
 
     @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId AND a.status = true")
     Long countByPostIdAndIsStatusTrue(@Param("postId") Long postId);

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -120,8 +120,9 @@ public class ApplicantService {
 
     public ApplicantResponse.CheckStatusDto checkStatus(Long userId, Long postId){
         Applicant applicant = applicantRepository.findByUserIdAndPostId(userId, postId).orElse(null);
-        boolean isApplicantPresent  = applicant != null;
-        return new ApplicantResponse.CheckStatusDto(isApplicantPresent , isApplicantPresent  && applicant.getStatus());
+        boolean isApplicantPresent = applicant != null;
+        Long applicantId = isApplicantPresent ? applicant.getId() : null;
+        return new ApplicantResponse.CheckStatusDto(applicantId, isApplicantPresent, isApplicantPresent && applicant.getStatus());
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -45,7 +45,7 @@ public class ApplicantService {
 
         Long participantNumber = applicantRepository.countByPostId(post.getId());
         Long currentNumber = applicantRepository.countByPostIdAndIsStatusTrue(post.getId());
-        List<Applicant> applicants = loadApplicants(cursorRequest, post.getId());
+        List<Applicant> applicants = loadApplicants(cursorRequest, post.getId(), userId);
         Long lastKey = getLastKey(applicants);
 
         var ratings = applicants.stream().map(applicant ->
@@ -62,14 +62,14 @@ public class ApplicantService {
                 ratings);
     }
 
-    private List<Applicant> loadApplicants(CursorRequest cursorRequest, Long postId) {
+    private List<Applicant> loadApplicants(CursorRequest cursorRequest, Long postId, Long userId) {
         int size = cursorRequest.hasSize() ? cursorRequest.size() : DEFAULT_SIZE;
         Pageable pageable = PageRequest.of(0, size);
 
-        if(!cursorRequest.hasKey()){
-            return applicantRepository.findAllByPostIdOrderByIdDesc(postId, pageable);
-        }else{
-            return applicantRepository.findAllByPostIdLessThanOrderByIdDesc(cursorRequest.key(), postId, pageable);
+        if (!cursorRequest.hasKey()) {
+            return applicantRepository.findAllByPostIdAndUserIdNotOrderByIdDesc(postId, userId, pageable);
+        } else {
+            return applicantRepository.findAllByPostIdAndUserIdNotLessThanOrderByIdDesc(cursorRequest.key(), postId, userId, pageable);
         }
     }
 


### PR DESCRIPTION
## Summary

신청 취소 api에서 applicant id를 얻을 수 없다는 요청이 들어와서 신청 상태 조회 response에 applicantId를 추가했습니다. 변경 사항을 서버에 빠르게 반영하면 좋을 것 같습니다! 

## Description

<!-- 상세 내용 작성 -->
- 사용자가 신청한 모집글을 신청 취소 하려면 신청 ID가 필요합니다. 신청 취소 기능을 위해 신청 상태 조회 api에 신청 id를 추가합니다. 신청을 하지 않았을 경우 null을 반환합니다. 
- 글 작성자를 applicant_tb에 추가하면서 신청자 목록 조회를 하면 글 작성자 정보도 전달되는 부분을 수정했습니다.  

## Related Issue

Issue Number: #52
