### PR TITLE
쪽지API 대화방목록조회 수정

### DIFF
--- a/src/main/java/com/bungaebowling/server/message/controller/MessageController.java
+++ b/src/main/java/com/bungaebowling/server/message/controller/MessageController.java
@@ -20,35 +20,35 @@ public class MessageController {
 
     // 대화방(쪽지) 목록 조회
     @GetMapping("/opponents")
-    public ResponseEntity<ApiUtils.Response> getOpponents(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> getOpponents(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails) {
         MessageResponse.GetOpponentsDto response = messageService.getOpponents(cursorRequest, userDetails.getId());
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }
 
     // 일대일 대화방 쪽지 조회
     @GetMapping("/opponents/{opponentId}")
-    public ResponseEntity<ApiUtils.Response> getMessagesAndUpdateToRead(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
+    public ResponseEntity<?> getMessagesAndUpdateToRead(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
         MessageResponse.GetMessagesDto response = messageService.getMessagesAndUpdateToRead(cursorRequest, userDetails.getId(), opponentId);
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }
 
     // 쪽지 보내기
     @PostMapping("/opponents/{opponentId}")
-    public ResponseEntity<ApiUtils.Response> sendMessage(@RequestBody @Valid MessageRequest.SendMessageDto requestDto, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
+    public ResponseEntity<?> sendMessage(@RequestBody @Valid MessageRequest.SendMessageDto requestDto, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
         messageService.sendMessage(requestDto, userDetails.getId(), opponentId);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 
     // 쪽지함 삭제
     @DeleteMapping("/opponents/{opponentId}")
-    public ResponseEntity<ApiUtils.Response> deleteMessagesByOpponentId(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
+    public ResponseEntity<?> deleteMessagesByOpponentId(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
         messageService.deleteMessagesByOpponentId(userDetails.getId(), opponentId);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 
     // 쪽지 개별 삭제
     @DeleteMapping("/{messageId}")
-    public ResponseEntity<ApiUtils.Response> deleteMessageById(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long messageId) {
+    public ResponseEntity<?> deleteMessageById(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long messageId) {
         messageService.deleteMessageById(userDetails.getId(), messageId);
         return ResponseEntity.ok().body(ApiUtils.success());
     }

--- a/src/main/java/com/bungaebowling/server/message/controller/MessageController.java
+++ b/src/main/java/com/bungaebowling/server/message/controller/MessageController.java
@@ -20,37 +20,36 @@ public class MessageController {
 
     // 대화방(쪽지) 목록 조회
     @GetMapping("/opponents")
-    public ResponseEntity<?> getOpponents(CursorRequest cursorRequest,@AuthenticationPrincipal CustomUserDetails userDetails) {
-        MessageResponse.GetOpponentsDto response = messageService.getOpponents(cursorRequest,userDetails.getId());
+    public ResponseEntity<ApiUtils.Response> getOpponents(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        MessageResponse.GetOpponentsDto response = messageService.getOpponents(cursorRequest, userDetails.getId());
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }
 
     // 일대일 대화방 쪽지 조회
     @GetMapping("/opponents/{opponentId}")
-    public ResponseEntity<?> getMessagesByOpponentId(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
-        MessageResponse.GetMessagesDto response = messageService.getMessagesByOpponentId(cursorRequest,userDetails.getId(),opponentId);
+    public ResponseEntity<ApiUtils.Response> getMessagesAndUpdateToRead(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
+        MessageResponse.GetMessagesDto response = messageService.getMessagesAndUpdateToRead(cursorRequest, userDetails.getId(), opponentId);
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }
 
     // 쪽지 보내기
     @PostMapping("/opponents/{opponentId}")
-    public ResponseEntity<?> sendMessage(@RequestBody @Valid MessageRequest.SendMessageDto requestDto, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId)
-     {
-         messageService.sendMessage(requestDto,userDetails.getId(),opponentId);
+    public ResponseEntity<ApiUtils.Response> sendMessage(@RequestBody @Valid MessageRequest.SendMessageDto requestDto, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
+        messageService.sendMessage(requestDto, userDetails.getId(), opponentId);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 
     // 쪽지함 삭제
     @DeleteMapping("/opponents/{opponentId}")
-    public ResponseEntity<?> deleteMessagesByOpponentId(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
-        messageService.deleteMessagesByOpponentId(userDetails.getId(),opponentId);
+    public ResponseEntity<ApiUtils.Response> deleteMessagesByOpponentId(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
+        messageService.deleteMessagesByOpponentId(userDetails.getId(), opponentId);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 
     // 쪽지 개별 삭제
     @DeleteMapping("/{messageId}")
-    public ResponseEntity<?> deleteMessageById( @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long messageId) {
-        messageService.deleteMessageById(userDetails.getId(),messageId);
+    public ResponseEntity<ApiUtils.Response> deleteMessageById(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long messageId) {
+        messageService.deleteMessageById(userDetails.getId(), messageId);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 

--- a/src/main/java/com/bungaebowling/server/message/dto/MessageResponse.java
+++ b/src/main/java/com/bungaebowling/server/message/dto/MessageResponse.java
@@ -1,25 +1,29 @@
 package com.bungaebowling.server.message.dto;
+
 import com.bungaebowling.server._core.utils.CursorRequest;
 import com.bungaebowling.server.message.Message;
 import com.bungaebowling.server.user.User;
+
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class MessageResponse {
     public record GetOpponentsDto(
-            Long countNew,
-            Long countAll,
             CursorRequest nextCursorRequest,
-
             List<MessageResponse.GetOpponentsDto.MessageDto> messages
     ) {
-        public static MessageResponse.GetOpponentsDto of(CursorRequest nextCursorRequest, Long countNew, Long countAll, List<Message> messages){
+        public static MessageResponse.GetOpponentsDto of(CursorRequest nextCursorRequest, List<Message> messages, Map<Long, Long> countNews) {
+
+
             return new MessageResponse.GetOpponentsDto(
-                    countNew,
-                    countAll,
                     nextCursorRequest,
-                    messages.stream().map(MessageResponse.GetOpponentsDto.MessageDto::new).toList()
+                    messages.stream()
+                            .map(message -> new MessageDto(message, countNews.getOrDefault(message.getOpponentUser().getId(), 0L)))
+                            .toList()
             );
+
+
         }
 
         public record MessageDto(
@@ -27,20 +31,20 @@ public class MessageResponse {
                 String opponentUserName,
                 String opponentUserProfileImage,
                 String recentMessage,
-                Boolean isNew
+                Long countNew
         ) {
-
-            public MessageDto(Message message) {
+            public MessageDto(Message message, Long countNew) {
                 this(
                         message.getOpponentUser().getId(),
                         message.getOpponentUser().getName(),
                         message.getOpponentUser().getImgUrl(),
                         message.getContent(),
-                        !message.getIsRead() && message.getIsReceive()
+                        countNew
                 );
             }
         }
     }
+
 
     public record GetMessagesDto(
             CursorRequest nextCursorRequest,

--- a/src/main/java/com/bungaebowling/server/message/repository/MessageRepository.java
+++ b/src/main/java/com/bungaebowling/server/message/repository/MessageRepository.java
@@ -45,7 +45,6 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     void deleteAllByUserIdAndOpponentUserId(Long userId, Long opponentId);
 
 
-    List<Message> findAllByUserId(Long userId);
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Message m SET m.isRead = true WHERE m.user.id = :userId AND m.opponentUser.id = :opponentId AND m.isRead = false")
     void updateIsReadTrueByUserIdAndOpponentUserId(Long userId, Long opponentId);

--- a/src/test/java/com/bungaebowling/server/message/MessageRepositoryTest.java
+++ b/src/test/java/com/bungaebowling/server/message/MessageRepositoryTest.java
@@ -1,4 +1,5 @@
 package com.bungaebowling.server.message;
+
 import com.bungaebowling.server.city.country.district.District;
 import com.bungaebowling.server.city.country.district.repository.DistrictRepository;
 import com.bungaebowling.server.message.repository.MessageRepository;
@@ -15,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Pageable;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -187,34 +189,6 @@ class MessageRepositoryTest {
         Assertions.assertThat(messages.get(1).getOpponentUser().getImgUrl()).isEqualTo("testimage1");
     }
 
-    @Test
-    @DisplayName("새로운 쪽지 갯수 조회")
-    void countByUserIdAndIsReceiveTrueAndIsReadFalse() {
-        //given
-        User testuser = userRepository.findByName("테스트유저3").get();
-        List<Message> messages = messageRepository.findAllByUserId(testuser.getId());
-        messages.get(0).read();
-        em.flush();
-        //when
-        System.out.println("====================start===================");
-        Long count = messageRepository.countByUserIdAndIsReceiveTrueAndIsReadFalse(testuser.getId());
-        System.out.println("========================end=====================");
-        //then
-        Assertions.assertThat(count).isEqualTo(19);
-    }
-
-    @Test
-    @DisplayName("전체 쪽지 갯수 조회")
-    void countByUserIdAndIsReceiveTrue() {
-        //given
-        User testuser = userRepository.findByName("테스트유저3").get();
-        //when
-        System.out.println("====================start===================");
-        Long count = messageRepository.countByUserIdAndIsReceiveTrue(testuser.getId());
-        System.out.println("========================end=====================");
-        //then
-        Assertions.assertThat(count).isEqualTo(20);
-    }
 
     @Test
     @DisplayName("일대일 대화방 쪽지 조회")


### PR DESCRIPTION
## Summary

대화방 목록 조회 수정

기존: 새로운메세지의 경우 유무만 알려줌 
수정: 새로운메세지의 수까지 알려줌
 
## Description


 DTO 수정
- 각 상대방별 isNew -> countNew 로 변경: 기존에는 새로운 메시지 여부만 반환하였는데 새로운메시지수를 반환해 주는 것으로 변경

- 전체 countAll 삭제

- 전체 countNew 삭제

레포지토리 메소드 추가
- 상대방별 새로운 메세지 갯수 조회를 위한 메소드 추가


삭제된 레포지토리 메소드의 테스트 코드 삭제

 
+) 일대일대화방의 메소드 명을 변경 
getMessagesByOpponent() -> getMessagesAndUpdateToRead()

## Related Issue


Issue Number:
 close #50 close #44 