### PR TITLE
별점 등록 api 구현

### DIFF
--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -22,14 +22,14 @@ public class ApplicantController {
 
     @GetMapping
     public ResponseEntity<?> getApplicants(@PathVariable Long postId, CursorRequest cursorRequest,
-                                           @AuthenticationPrincipal CustomUserDetails userDetails){
+                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
         ApplicantResponse.GetApplicantsDto getApplicantsDto = applicantService.getApplicants(userDetails.getId(), postId, cursorRequest);
         var response = ApiUtils.success(getApplicantsDto);
         return ResponseEntity.ok().body(response);
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<?> create(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         applicantService.create(userDetails.getId(), postId);
         return ResponseEntity.ok(ApiUtils.success());
     }
@@ -38,7 +38,7 @@ public class ApplicantController {
     public ResponseEntity<?> accept(@AuthenticationPrincipal CustomUserDetails userDetails,
                                     @PathVariable String postId,
                                     @PathVariable Long applicantId,
-                                    @RequestBody @Valid ApplicantRequest.UpdateDto requestDto, Errors errors){
+                                    @RequestBody @Valid ApplicantRequest.UpdateDto requestDto, Errors errors) {
         applicantService.accept(userDetails.getId(), applicantId, requestDto);
         return ResponseEntity.ok(ApiUtils.success());
     }
@@ -46,15 +46,24 @@ public class ApplicantController {
     @DeleteMapping("/{applicantId}")
     public ResponseEntity<?> reject(@AuthenticationPrincipal CustomUserDetails userDetails,
                                     @PathVariable String postId,
-                                    @PathVariable Long applicantId){
+                                    @PathVariable Long applicantId) {
         applicantService.reject(userDetails.getId(), applicantId);
         return ResponseEntity.ok(ApiUtils.success());
     }
 
     @GetMapping("/check-status")
     public ResponseEntity<?> checkStatus(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                         @PathVariable Long postId){
+                                         @PathVariable Long postId) {
         var response = applicantService.checkStatus(userDetails.getId(), postId);
         return ResponseEntity.ok(ApiUtils.success(response));
+    }
+
+    @PostMapping("/{applicantId}/rating")
+    public ResponseEntity<?> rateUser(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                      @PathVariable String postId,
+                                      @PathVariable Long applicantId,
+                                      @RequestBody @Valid ApplicantRequest.RateDto requestDto, Errors errors) {
+        applicantService.rateUser(applicantId, requestDto);
+        return ResponseEntity.ok().body(ApiUtils.success());
     }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -63,7 +63,7 @@ public class ApplicantController {
                                       @PathVariable String postId,
                                       @PathVariable Long applicantId,
                                       @RequestBody @Valid ApplicantRequest.RateDto requestDto, Errors errors) {
-        applicantService.rateUser(applicantId, requestDto);
+        applicantService.rateUser(userDetails.getId(), applicantId, requestDto);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
@@ -8,4 +8,12 @@ public class ApplicantRequest {
             @NotNull
             Boolean status
     ){}
+
+    public record RateDto(
+            @NotNull
+            Long targetId,
+            @NotNull
+            Integer rating
+    ) {
+    }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
@@ -1,5 +1,7 @@
 package com.bungaebowling.server.applicant.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public class ApplicantRequest {
@@ -12,7 +14,8 @@ public class ApplicantRequest {
     public record RateDto(
             @NotNull
             Long targetId,
-            @NotNull
+            @Max(value = 5, message = "1 ~ 5 사이 값만 가능합니다.")
+            @Min(value = 1, message = "1 ~ 5 사이 값만 가능합니다.")
             Integer rating
     ) {
     }

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -155,6 +155,36 @@ public class ApplicantService {
         return Objects.equals(post.getUser().getId(), userId);
     }
 
-    public void rateUser(Long applicantId, ApplicantRequest.RateDto requestDto) {
+    @Transactional
+    public void rateUser(Long userId, Long applicantId, ApplicantRequest.RateDto requestDto) {
+        var applicant = getApplicantWithPost(applicantId);
+
+        var isMine = Objects.equals(applicant.getUser().getId(), userId);
+        var isAccept = applicant.getStatus();
+        var isAvailable = applicant.getPost().getIsClose() && LocalDateTime.now().isAfter(applicant.getPost().getStartTime());
+
+        if (!isMine) throw new Exception403("자신의 신청이 아닙니다.");
+        if (!(isAccept && isAvailable)) throw new Exception400("등록할 수 있는 상태가 아닙니다.");
+
+        var targetApplicant = applicantRepository.findByUserIdAndPostId(requestDto.targetId(), applicant.getPost().getId()).orElse(null);
+
+        var checkTarget = targetApplicant != null && !Objects.equals(targetApplicant.getUser().getId(), userId) && targetApplicant.getStatus();
+        if (!checkTarget) {
+            throw new Exception400("잘못된 요청입니다.");
+        }
+        
+        userRateRepository.findAllByApplicantId(applicantId).forEach(userRate -> {
+            if (Objects.equals(userRate.getUser().getId(), requestDto.targetId())) throw new Exception400("이미 등록되었습니다.");
+        });
+
+        var targetUser = userRepository.findById(requestDto.targetId()).orElseThrow(() -> new Exception404("존재하지 않는 유저입니다."));
+
+        var rate = UserRate.builder()
+                .applicant(applicant)
+                .user(targetUser)
+                .starCount(requestDto.rating())
+                .build();
+
+        userRateRepository.save(rate);
     }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -154,4 +154,7 @@ public class ApplicantService {
     private boolean isMatchedUser(Long userId, Post post) {
         return Objects.equals(post.getUser().getId(), userId);
     }
+
+    public void rateUser(Long applicantId, ApplicantRequest.RateDto requestDto) {
+    }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4735,14 +4735,115 @@ VALUES
 -- 비밀번호는 test12!@
 INSERT INTO user_tb (name, email, password, district_id, role)
 VALUES ('김볼링', 'test@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
-       ('볼링볼링', 'test1@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
+       ('볼링볼링', 'test1@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('박볼', 'test3@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링링', 'test4@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('볼링링', 'test5@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼', 'test6@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링륑', 'test7@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('주주', 'test8@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('son', 'test9@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼2', 'test10@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('볼링링1', 'test11@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('볼스', 'test12@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링2', 'test13@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링3', 'test14@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링4', 'test15@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링5', 'test16@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링6', 'test17@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링7', 'test18@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링8', 'test19@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링9', 'test20@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링10', 'test21@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링11', 'test22@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링12', 'test23@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링13', 'test24@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링14', 'test25@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링15', 'test26@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
 
-INSERT INTO post_tb (title, user_id, district_id, start_time, due_time, content)
-VALUES ('불금 볼링 점수 내기 하실 분~', 1, 1, '2023-12-01', '2023-11-29', '볼링 점수 내기합시다.');
+INSERT INTO post_tb (title, user_id, district_id, start_time, due_time, content, is_close)
+VALUES ('불금 볼링 점수 내기 하실 분~', 1, 1, '2023-12-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 1, 469, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 1, 469, '2023-09-08', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 1, 469, '2023-09-08', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 1, 469, '2023-08-05', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 3, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 4, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 4, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 4, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 1, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-10-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-10-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true);
 
-INSERT INTO applicant_tb (status, user_id, post_id)
-VALUES (true, 1, 1);
+INSERT INTO applicant_tb (user_id, post_id, status)
+VALUES (1, 1, true),
+       (1, 2, true),
+       (1, 3, true),
+       (1, 4, true),
+       (1, 5, true),
+       (2, 6, true),
+       (2, 7, true),
+       (2, 8, true),
+       (2, 9, true),
+       (2, 10, true),
+       (3, 11, true),
+       (3, 12, true),
+       (3, 13, true),
+       (3, 14, true),
+       (3, 15, true),
+       (4, 16, true),
+       (4, 17, true),
+       (4, 18, true),
+       (4, 19, true),
+       (4, 20, true),
+       -- 여기까지 자신의 모집글에 자동 신청
+       (1, 6, true),
+       (1, 7, false),
+       (1, 8, false),
+       (1, 9, false),
+       (1, 10, false),
+       (1, 11, false),
+       (1, 12, false),
+       (1, 13, false),
+       (1, 14, false),
+       (1, 15, false),
+       (1, 16, true),
+       (1, 17, true),
+       (1, 18, true),
+       (1, 19, true),
+       (1, 20, true),
+       (2, 1, true),
+       (3, 2, true),
+       (4, 1, true),
+       (5, 1, true),
+       (11, 6, true),
+       (7, 6, true),
+       (8, 6, true),
+       (9, 6, true),
+       (10, 6, true);
 
 INSERT INTO comment_tb (post_id, user_id, parent_id, content)
 VALUES (1, 2, null, '저 해도 되나요?'),
        (1, 1, 1, '신청해주세요~');
+
+INSERT INTO score_tb (user_id, post_id, score_num)
+VALUES (1, 6, 100),
+       (1, 1, 150),
+       (1, 6, 45);
+
+INSERT INTO user_rate_tb(applicant_id, user_id, star_count)
+VALUES (1, 2, 5),
+       (1, 4, 5),
+       (1, 5, 5),
+       (20, 1, 5),
+       (19, 1, 5),
+       (18, 1, 4),
+       (17, 1, 1);


### PR DESCRIPTION
## Summary

게임 플레이 후의 별점 등록을 구현 완료하였습니다.

## Description

request 형태

```json
{
  "targetId": 4,
  "rating": 4
}
```

test@test.com으로 로그인 후 /api/posts/16/applicants/31/rating 으로 테스트 가능합니다.

---

사용자는 모집글에 대해 신청하고, 자신의 신청이 수락되었을 때, 게임 플레이 종료 후 자신의 신청 id를 사용하여 같이 플레이한 사람들에게 별점을 등록할 수 있습니다.

따라서 유효성 체크는 다음과 같습니다.
1. path의 신청id가 자신의 것이여야 합니다.
2. 자신의 신청이 수락된 상태(모집자가 승낙)여야 합니다.
3. 모집글이 모집완료(모집자가 마감 버튼 클릭; isClose 컬럼이 true)여야합니다.
4. 모집글의 시작시간 이후여야 합니다.(게임 플레이 시작 한 후부터 별점 가능)

아래는 requestBody에 대한 유효성입니다.
1. targetId는 같은 모집글에 신청한 유저의 id여야 합니다.
2. targetId가 신청한 신청은 수락된 상태여야 합니다.
3. targetId는 자신이면 안됩니다.
4. 별점은 1 ~ 5만 가능합니다.

---

추가적으로 더미 데이터를 추가하였습니다. 기본은 #41 의 테스트 데이터에 db 구조에 맞게 일부 수정을 가한 형태입니다.