### PR TITLE
6주차 개발 내역 정리

### DIFF
--- a/src/main/java/com/bungaebowling/server/_core/utils/AwsS3Service.java
+++ b/src/main/java/com/bungaebowling/server/_core/utils/AwsS3Service.java
@@ -45,6 +45,16 @@ public class AwsS3Service {
         return safeFileName;
     }
 
+    //프로필 이미지 등록
+    public String uploadProfileFile(Long userId, String category, LocalDateTime time, MultipartFile multipartFile) {
+        String fileName = CommonUtils.buildProfileFileName(userId, category, time, Objects.requireNonNull(multipartFile.getOriginalFilename()));
+        String safeFileName = fileWhiteList(fileName);
+
+        uploadFileToS3(safeFileName, multipartFile);
+
+        return safeFileName;
+    }
+
     // 단일 파일용 - 알아서 잘 custom해서 사용하면 됨
     public String uploadFile(Long userId, String category, MultipartFile multipartFile) {
         String fileName = CommonUtils.buildFileName(category, Objects.requireNonNull(multipartFile.getOriginalFilename()));

--- a/src/main/java/com/bungaebowling/server/_core/utils/CommonUtils.java
+++ b/src/main/java/com/bungaebowling/server/_core/utils/CommonUtils.java
@@ -19,6 +19,17 @@ public class CommonUtils {
         return "user" + WORD_SEPARATOR + userId + CATEGORY_PREFIX + postId + CATEGORY_PREFIX + category + CATEGORY_PREFIX + fileName + TIME_SEPARATOR + now + fileExtension;
     }
 
+    //프로필 등록
+    public static String buildProfileFileName(Long userId, String category, LocalDateTime time, String originalFileName) {
+        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR); // 파일 확장자 구분선
+        String fileExtension = originalFileName.substring(fileExtensionIndex); // 파일 확장자
+        String fileName = originalFileName.substring(0, fileExtensionIndex); // 파일 이름
+        String now = String.valueOf(time); // 파일 업로드 시간
+
+        //작성자(user_1)/profile/파일명/파일업로드시간.확장자
+        return "user" + WORD_SEPARATOR + userId + CATEGORY_PREFIX + category + CATEGORY_PREFIX + fileName + TIME_SEPARATOR + now + fileExtension;
+    }
+
     // 단일 파일용 -> 이것도 사용 용도에 맞게 custom해서 써야 함
     public static String buildFileName(String category, String originalFileName) {
         int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR); // 파일 확장자 구분선

--- a/src/main/java/com/bungaebowling/server/applicant/Applicant.java
+++ b/src/main/java/com/bungaebowling/server/applicant/Applicant.java
@@ -28,15 +28,12 @@ public class Applicant {
     private Boolean status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id", referencedColumnName = "id")
+    @JoinColumn(name = "post_id")
     private Post post;
-
-    //@OneToOne
-    //private UserRate userRate;
 
     @ColumnDefault("now()")
     private LocalDateTime createdAt;

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -22,14 +22,14 @@ public class ApplicantController {
 
     @GetMapping
     public ResponseEntity<?> getApplicants(@PathVariable Long postId, CursorRequest cursorRequest,
-                                           @AuthenticationPrincipal CustomUserDetails userDetails){
+                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
         ApplicantResponse.GetApplicantsDto getApplicantsDto = applicantService.getApplicants(userDetails.getId(), postId, cursorRequest);
         var response = ApiUtils.success(getApplicantsDto);
         return ResponseEntity.ok().body(response);
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<?> create(@PathVariable Long postId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         applicantService.create(userDetails.getId(), postId);
         return ResponseEntity.ok(ApiUtils.success());
     }
@@ -38,7 +38,7 @@ public class ApplicantController {
     public ResponseEntity<?> accept(@AuthenticationPrincipal CustomUserDetails userDetails,
                                     @PathVariable String postId,
                                     @PathVariable Long applicantId,
-                                    @RequestBody @Valid ApplicantRequest.UpdateDto requestDto, Errors errors){
+                                    @RequestBody @Valid ApplicantRequest.UpdateDto requestDto, Errors errors) {
         applicantService.accept(userDetails.getId(), applicantId, requestDto);
         return ResponseEntity.ok(ApiUtils.success());
     }
@@ -46,15 +46,24 @@ public class ApplicantController {
     @DeleteMapping("/{applicantId}")
     public ResponseEntity<?> reject(@AuthenticationPrincipal CustomUserDetails userDetails,
                                     @PathVariable String postId,
-                                    @PathVariable Long applicantId){
+                                    @PathVariable Long applicantId) {
         applicantService.reject(userDetails.getId(), applicantId);
         return ResponseEntity.ok(ApiUtils.success());
     }
 
     @GetMapping("/check-status")
     public ResponseEntity<?> checkStatus(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                         @PathVariable Long postId){
+                                         @PathVariable Long postId) {
         var response = applicantService.checkStatus(userDetails.getId(), postId);
         return ResponseEntity.ok(ApiUtils.success(response));
+    }
+
+    @PostMapping("/{applicantId}/rating")
+    public ResponseEntity<?> rateUser(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                      @PathVariable String postId,
+                                      @PathVariable Long applicantId,
+                                      @RequestBody @Valid ApplicantRequest.RateDto requestDto, Errors errors) {
+        applicantService.rateUser(userDetails.getId(), applicantId, requestDto);
+        return ResponseEntity.ok().body(ApiUtils.success());
     }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/bungaebowling/server/applicant/controller/ApplicantController.java
@@ -50,4 +50,11 @@ public class ApplicantController {
         applicantService.reject(userDetails.getId(), applicantId);
         return ResponseEntity.ok(ApiUtils.success());
     }
+
+    @GetMapping("/check-status")
+    public ResponseEntity<?> checkStatus(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                         @PathVariable Long postId){
+        var response = applicantService.checkStatus(userDetails.getId(), postId);
+        return ResponseEntity.ok(ApiUtils.success(response));
+    }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantRequest.java
@@ -1,5 +1,7 @@
 package com.bungaebowling.server.applicant.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public class ApplicantRequest {
@@ -8,4 +10,13 @@ public class ApplicantRequest {
             @NotNull
             Boolean status
     ){}
+
+    public record RateDto(
+            @NotNull
+            Long targetId,
+            @Max(value = 5, message = "1 ~ 5 사이 값만 가능합니다.")
+            @Min(value = 1, message = "1 ~ 5 사이 값만 가능합니다.")
+            Integer rating
+    ) {
+    }
 }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -54,12 +54,12 @@ public class ApplicantResponse {
                     );
                 }
             }
-
         }
     }
 
     public record CheckStatusDto(
-            Boolean isApplied, //신청됨
-            Boolean isAccepted //수락됨
+            Long applicantId,
+            Boolean isApplied, //신청 여부
+            Boolean isAccepted //수락 여부
     ) {}
 }

--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -3,7 +3,6 @@ package com.bungaebowling.server.applicant.dto;
 import com.bungaebowling.server._core.utils.CursorRequest;
 import com.bungaebowling.server.applicant.Applicant;
 import com.bungaebowling.server.user.User;
-import com.bungaebowling.server.user.rate.UserRate;
 
 import java.util.List;
 import java.util.stream.IntStream;
@@ -58,4 +57,9 @@ public class ApplicantResponse {
 
         }
     }
+
+    public record CheckStatusDto(
+            Boolean isApplied, //신청됨
+            Boolean isAccepted //수락됨
+    ) {}
 }

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -16,11 +16,11 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     @Query("SELECT a FROM Applicant a WHERE a.user.id = :userId AND a.post.id = :postId")
     Optional<Applicant> findByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
 
-    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId ORDER BY a.id DESC")
-    List<Applicant> findAllByPostIdOrderByIdDesc(@Param("postId") Long postId, Pageable pageable);
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND u.id != :userId ORDER BY a.id DESC")
+    List<Applicant> findAllByPostIdAndUserIdNotOrderByIdDesc(@Param("postId") Long postId, @Param("userId") Long userId, Pageable pageable);
 
-    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND a.id < :key ORDER BY a.id DESC")
-    List<Applicant> findAllByPostIdLessThanOrderByIdDesc(@Param("key") Long key, @Param("postId") Long postId, Pageable pageable);
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND u.id != :userId AND a.id < :key ORDER BY a.id DESC")
+    List<Applicant> findAllByPostIdAndUserIdNotLessThanOrderByIdDesc(@Param("key") Long key, @Param("postId") Long postId, @Param("userId") Long userId, Pageable pageable);
 
     @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId AND a.status = true")
     Long countByPostIdAndIsStatusTrue(@Param("postId") Long postId);

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -30,4 +30,9 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
 
     @Query("SELECT a FROM Applicant a JOIN FETCH a.post p WHERE a.id = :id")
     Optional<Applicant> findByIdJoinFetchPost(@Param("id") Long id);
+
+    List<Applicant> findAllByUserIdAndPostIsCloseTrueAndStatusTrue(Long userId);
+
+    @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId and a.status = true  ORDER BY u.id DESC")
+    List<Applicant> findAllByPostIdAndStatusTrueOrderByUserIdDesc(@Param("postId") Long postId);
 }

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -39,19 +40,19 @@ public class ApplicantService {
     public ApplicantResponse.GetApplicantsDto getApplicants(Long userId, Long postId, CursorRequest cursorRequest){
         Post post = getPost(postId);
 
-        if (!Objects.equals(post.getUser().getId(), userId))
+        if (!isMatchedUser(userId, post))
             throw new Exception403("자신의 모집글이 아닙니다.");
 
         Long participantNumber = applicantRepository.countByPostId(post.getId());
         Long currentNumber = applicantRepository.countByPostIdAndIsStatusTrue(post.getId());
         List<Applicant> applicants = loadApplicants(cursorRequest, post.getId());
-        Long lastKey = applicants.isEmpty() ? CursorRequest.NONE_KEY : applicants.get(applicants.size() - 1).getId();
+        Long lastKey = getLastKey(applicants);
 
-        var ratings = applicants.stream().map(applicant -> {
-                    return userRateRepository.findAllByUserId(applicant.getUser().getId()).stream()
+        var ratings = applicants.stream().map(applicant ->
+                     userRateRepository.findAllByUserId(applicant.getUser().getId()).stream()
                             .mapToInt(UserRate::getStarCount)
-                            .average().orElse(0.0);
-                }).toList();
+                            .average().orElse(0.0)
+                ).toList();
 
         return ApplicantResponse.GetApplicantsDto.of(
                 cursorRequest.next(lastKey, DEFAULT_SIZE),
@@ -77,15 +78,21 @@ public class ApplicantService {
         User user = getUser(userId);
         Post post = getPost(postId);
 
-        if (Objects.equals(post.getUser().getId(), user.getId()))
+        if (isMatchedUser(userId, post))
             throw new Exception400("본인의 모집글에 신청할 수 없습니다.");
 
-        //신청 중복 확인
         applicantRepository.findByUserIdAndPostId(userId, postId).ifPresent(applicant -> {
             throw new Exception400("이미 신청된 사용자입니다.");
         });
 
-        Applicant applicant = Applicant.builder().user(user).post(post).build();
+        if(isPastDueTime(post)){
+            throw new Exception400("이미 마감된 모집글입니다.");
+        }
+
+        Applicant applicant = Applicant.builder()
+                .user(user)
+                .post(post)
+                .build();
         applicantRepository.save(applicant);
     }
 
@@ -104,10 +111,17 @@ public class ApplicantService {
         Applicant applicant = getApplicantWithPost(applicantId);
         var isPostOwner = Objects.equals(userId, applicant.getPost().getUser().getId());
         var isApplicantOwner = Objects.equals(userId, applicant.getUser().getId());
+
         if (!(isApplicantOwner || isPostOwner))
             throw new Exception403("권한이 없습니다.");
 
         applicantRepository.delete(applicant);
+    }
+
+    public ApplicantResponse.CheckStatusDto checkStatus(Long userId, Long postId){
+        Applicant applicant = applicantRepository.findByUserIdAndPostId(userId, postId).orElse(null);
+        boolean isApplicantPresent  = applicant != null;
+        return new ApplicantResponse.CheckStatusDto(isApplicantPresent , isApplicantPresent  && applicant.getStatus());
     }
 
     private User getUser(Long userId) {
@@ -126,5 +140,17 @@ public class ApplicantService {
         return applicantRepository.findByIdJoinFetchPost(applicantId).orElseThrow(
                 () -> new Exception404("존재하지 않는 신청입니다.")
         );
+    }
+
+    private Long getLastKey(List<Applicant> applicants) {
+        return applicants.isEmpty() ? CursorRequest.NONE_KEY : applicants.get(applicants.size() - 1).getId();
+    }
+
+    private boolean isPastDueTime(Post post) {
+        return post.getIsClose() || LocalDateTime.now().isAfter(post.getDueTime());
+    }
+
+    private boolean isMatchedUser(Long userId, Post post) {
+        return Objects.equals(post.getUser().getId(), userId);
     }
 }

--- a/src/main/java/com/bungaebowling/server/message/controller/MessageController.java
+++ b/src/main/java/com/bungaebowling/server/message/controller/MessageController.java
@@ -20,37 +20,36 @@ public class MessageController {
 
     // 대화방(쪽지) 목록 조회
     @GetMapping("/opponents")
-    public ResponseEntity<?> getOpponents(CursorRequest cursorRequest,@AuthenticationPrincipal CustomUserDetails userDetails) {
-        MessageResponse.GetOpponentsDto response = messageService.getOpponents(cursorRequest,userDetails.getId());
+    public ResponseEntity<?> getOpponents(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        MessageResponse.GetOpponentsDto response = messageService.getOpponents(cursorRequest, userDetails.getId());
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }
 
     // 일대일 대화방 쪽지 조회
     @GetMapping("/opponents/{opponentId}")
-    public ResponseEntity<?> getMessagesByOpponentId(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
-        MessageResponse.GetMessagesDto response = messageService.getMessagesByOpponentId(cursorRequest,userDetails.getId(),opponentId);
+    public ResponseEntity<?> getMessagesAndUpdateToRead(CursorRequest cursorRequest, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
+        MessageResponse.GetMessagesDto response = messageService.getMessagesAndUpdateToRead(cursorRequest, userDetails.getId(), opponentId);
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }
 
     // 쪽지 보내기
     @PostMapping("/opponents/{opponentId}")
-    public ResponseEntity<?> sendMessage(@RequestBody @Valid MessageRequest.SendMessageDto requestDto, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId)
-     {
-         messageService.sendMessage(requestDto,userDetails.getId(),opponentId);
+    public ResponseEntity<?> sendMessage(@RequestBody @Valid MessageRequest.SendMessageDto requestDto, @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
+        messageService.sendMessage(requestDto, userDetails.getId(), opponentId);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 
     // 쪽지함 삭제
     @DeleteMapping("/opponents/{opponentId}")
     public ResponseEntity<?> deleteMessagesByOpponentId(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long opponentId) {
-        messageService.deleteMessagesByOpponentId(userDetails.getId(),opponentId);
+        messageService.deleteMessagesByOpponentId(userDetails.getId(), opponentId);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 
     // 쪽지 개별 삭제
     @DeleteMapping("/{messageId}")
-    public ResponseEntity<?> deleteMessageById( @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long messageId) {
-        messageService.deleteMessageById(userDetails.getId(),messageId);
+    public ResponseEntity<?> deleteMessageById(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long messageId) {
+        messageService.deleteMessageById(userDetails.getId(), messageId);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 

--- a/src/main/java/com/bungaebowling/server/message/dto/MessageResponse.java
+++ b/src/main/java/com/bungaebowling/server/message/dto/MessageResponse.java
@@ -1,25 +1,29 @@
 package com.bungaebowling.server.message.dto;
+
 import com.bungaebowling.server._core.utils.CursorRequest;
 import com.bungaebowling.server.message.Message;
 import com.bungaebowling.server.user.User;
+
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class MessageResponse {
     public record GetOpponentsDto(
-            Long countNew,
-            Long countAll,
             CursorRequest nextCursorRequest,
-
             List<MessageResponse.GetOpponentsDto.MessageDto> messages
     ) {
-        public static MessageResponse.GetOpponentsDto of(CursorRequest nextCursorRequest, Long countNew, Long countAll, List<Message> messages){
+        public static MessageResponse.GetOpponentsDto of(CursorRequest nextCursorRequest, List<Message> messages, Map<Long, Long> countNews) {
+
+
             return new MessageResponse.GetOpponentsDto(
-                    countNew,
-                    countAll,
                     nextCursorRequest,
-                    messages.stream().map(MessageResponse.GetOpponentsDto.MessageDto::new).toList()
+                    messages.stream()
+                            .map(message -> new MessageDto(message, countNews.getOrDefault(message.getOpponentUser().getId(), 0L)))
+                            .toList()
             );
+
+
         }
 
         public record MessageDto(
@@ -27,20 +31,20 @@ public class MessageResponse {
                 String opponentUserName,
                 String opponentUserProfileImage,
                 String recentMessage,
-                Boolean isNew
+                Long countNew
         ) {
-
-            public MessageDto(Message message) {
+            public MessageDto(Message message, Long countNew) {
                 this(
                         message.getOpponentUser().getId(),
                         message.getOpponentUser().getName(),
                         message.getOpponentUser().getImgUrl(),
                         message.getContent(),
-                        !message.getIsRead() && message.getIsReceive()
+                        countNew
                 );
             }
         }
     }
+
 
     public record GetMessagesDto(
             CursorRequest nextCursorRequest,

--- a/src/main/java/com/bungaebowling/server/message/repository/MessageRepository.java
+++ b/src/main/java/com/bungaebowling/server/message/repository/MessageRepository.java
@@ -1,4 +1,5 @@
 package com.bungaebowling.server.message.repository;
+
 import com.bungaebowling.server.message.Message;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -6,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
 import java.util.List;
 
 
@@ -13,27 +15,22 @@ import java.util.List;
 public interface MessageRepository extends JpaRepository<Message, Long> {
 
 
-
     @Query("SELECT m " +
             "FROM Message m " +
             "JOIN FETCH m.opponentUser oppUser " +
-            "WHERE m.id " +
-            "IN (SELECT MAX(m2.id) FROM Message m2 WHERE m2.user.id = :userId GROUP BY m2.opponentUser.id) " +
-            "And (:key IS NULL OR m.id < :key)"+
+            "WHERE m.id IN (SELECT MAX(m2.id) FROM Message m2 WHERE m2.user.id = :userId " +
+            "GROUP BY m2.opponentUser.id) " +
+            "And (:key IS NULL OR m.id < :key)" +
             "ORDER BY m.id DESC")
-    List<Message> findLatestMessagesPerOpponentByUserId(@Param("userId") Long userId,@Param("key") Long key, Pageable pageable);
+    List<Message> findLatestMessagesPerOpponentByUserId(@Param("userId") Long userId, @Param("key") Long key, Pageable pageable);
 
-
-
-    @Query("SELECT count(m) " +
+    @Query("SELECT m.opponentUser.id, COUNT(m) " +
             "FROM Message m " +
-            "WHERE m.user.id = :userId AND m.isRead = false And m.isReceive = true ")
-    Long countByUserIdAndIsReceiveTrueAndIsReadFalse(@Param("userId") Long userId);
-
-    @Query("SELECT count(m) " +
-            "FROM Message m " +
-            "WHERE m.user.id = :userId And m.isReceive = true ")
-    Long countByUserIdAndIsReceiveTrue(@Param("userId") Long userId);
+            "WHERE m.user.id = :userId AND m.isRead = false And m.isReceive = true " +
+            "And (:key IS NULL OR m.id < :key) " +
+            "GROUP BY m.opponentUser.id " +
+            "ORDER BY MAX(m.id) DESC")
+    List<Long[]> countUnreadMessagesWithOpponents(@Param("userId") Long userId, @Param("key") Long key, Pageable pageable);
 
 
     @Query("SELECT m " +
@@ -48,7 +45,6 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     void deleteAllByUserIdAndOpponentUserId(Long userId, Long opponentId);
 
 
-    List<Message> findAllByUserId(Long userId);
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Message m SET m.isRead = true WHERE m.user.id = :userId AND m.opponentUser.id = :opponentId AND m.isRead = false")
     void updateIsReadTrueByUserIdAndOpponentUserId(Long userId, Long opponentId);

--- a/src/main/java/com/bungaebowling/server/message/service/MessageService.java
+++ b/src/main/java/com/bungaebowling/server/message/service/MessageService.java
@@ -1,4 +1,5 @@
 package com.bungaebowling.server.message.service;
+
 import com.bungaebowling.server._core.errors.exception.client.Exception400;
 import com.bungaebowling.server._core.errors.exception.client.Exception404;
 import com.bungaebowling.server._core.utils.CursorRequest;
@@ -13,7 +14,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -28,54 +32,79 @@ public class MessageService {
     public MessageResponse.GetOpponentsDto getOpponents(CursorRequest cursorRequest, Long userId) {
         int size = cursorRequest.hasSize() ? cursorRequest.size() : DEFAULT_SIZE;
         Pageable pageable = PageRequest.of(0, size);
-        userRepository.findById(userId).orElseThrow(()->new Exception404("존재하지 않는 유저입니다."));
+
+       getUser(userId);
+
         List<Message> messages = messageRepository.findLatestMessagesPerOpponentByUserId(userId, cursorRequest.key(), pageable);
-        Long countNew = messageRepository.countByUserIdAndIsReceiveTrueAndIsReadFalse(userId);
-        Long countAll = messageRepository.countByUserIdAndIsReceiveTrue(userId);
-        Long lastKey = messages.isEmpty() ? CursorRequest.NONE_KEY : messages.get(messages.size()-1).getId();
-        return MessageResponse.GetOpponentsDto.of(cursorRequest.next(lastKey, DEFAULT_SIZE),countNew,countAll,messages);
+
+        Map<Long, Long> countNews = messageRepository.countUnreadMessagesWithOpponents(userId, cursorRequest.key(), pageable)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> row[0],
+                        row -> row[1]
+                ));
+
+        Long lastKey = messages.isEmpty() ? CursorRequest.NONE_KEY : messages.get(messages.size() - 1).getId();
+        return MessageResponse.GetOpponentsDto.of(cursorRequest.next(lastKey, DEFAULT_SIZE), messages, countNews);
     }
 
 
     @Transactional
-    public MessageResponse.GetMessagesDto getMessagesByOpponentId(CursorRequest cursorRequest, Long userId, Long opponentId) {
-        if (userId.equals(opponentId)){throw new Exception400("본인과 쪽지 대화를 할 수 없습니다.");}
-        User opponentUser = userRepository.findById(opponentId).orElseThrow(()->new Exception404("존재하지 않는 유저입니다."));
-        // 벌크 업데이트 쿼리 - 작업 후 영속성 초기화 실행
-        messageRepository.updateIsReadTrueByUserIdAndOpponentUserId(userId,opponentId);
-
+    public MessageResponse.GetMessagesDto getMessagesAndUpdateToRead(CursorRequest cursorRequest, Long userId, Long opponentId) {
         int size = cursorRequest.hasSize() ? cursorRequest.size() : DEFAULT_SIZE;
         Pageable pageable = PageRequest.of(0, size);
-        List<Message> messages= messageRepository.findAllByUserIdAndOpponentUserIdOrderByIdDesc(userId,opponentId,cursorRequest.key(), pageable);
-        Long lastKey = messages.isEmpty() ? CursorRequest.NONE_KEY : messages.get(messages.size()-1).getId();
 
-        return MessageResponse.GetMessagesDto.of(cursorRequest.next(lastKey, DEFAULT_SIZE),messages,opponentUser);
+        userCheck(userId, opponentId);
+
+        User opponentUser = getUser(opponentId);
+        messageRepository.updateIsReadTrueByUserIdAndOpponentUserId(userId, opponentId);
+
+        List<Message> messages = messageRepository.findAllByUserIdAndOpponentUserIdOrderByIdDesc(userId, opponentId, cursorRequest.key(), pageable);
+
+        Long lastKey = messages.isEmpty() ? CursorRequest.NONE_KEY : messages.get(messages.size() - 1).getId();
+        return MessageResponse.GetMessagesDto.of(cursorRequest.next(lastKey, DEFAULT_SIZE), messages, opponentUser);
     }
 
     @Transactional
     public void sendMessage(MessageRequest.SendMessageDto requestDto, Long userId, Long opponentId) {
-        if (userId.equals(opponentId)){throw new Exception400("본인과 쪽지 대화를 할 수 없습니다.");}
-        User user = userRepository.findById(userId).orElseThrow(()->new Exception404("존재하지 않는 유저입니다."));
-        User opponentUser = userRepository.findById(opponentId).orElseThrow(()->new Exception404("존재하지 않는 유저입니다."));
-        Message userMessage = requestDto.toEntity(user,opponentUser,false,true);
-        Message opponentMessage = requestDto.toEntity(opponentUser,user,true,false);
+        userCheck(userId, opponentId);
+        User user = getUser(userId);
+        User opponentUser = getUser(opponentId);
+
+        Message userMessage = requestDto.toEntity(user, opponentUser, false, true);
+        Message opponentMessage = requestDto.toEntity(opponentUser, user, true, false);
         messageRepository.save(userMessage);
         messageRepository.save(opponentMessage);
     }
 
     @Transactional
     public void deleteMessagesByOpponentId(Long userId, Long opponentId) {
-        if (userId.equals(opponentId)){throw new Exception400("본인과 쪽지 대화를 할 수 없습니다.");}
-        userRepository.findById(userId).orElseThrow(()->new Exception404("존재하지 않는 유저입니다."));
-        messageRepository.deleteAllByUserIdAndOpponentUserId(userId,opponentId);
+        userCheck(userId, opponentId);
+        getUser(userId);
+
+        messageRepository.deleteAllByUserIdAndOpponentUserId(userId, opponentId);
     }
-    
+
     @Transactional
     public void deleteMessageById(Long userId, Long messageId) {
-        Message message = messageRepository.findById(messageId).orElseThrow(()-> new Exception404("존재하지 않는 쪽지입니다."));
-        if (!userId.equals(message.getUser().getId())){
+        Message message = messageRepository.findById(messageId).orElseThrow(() -> new Exception404("존재하지 않는 쪽지입니다."));
+        if (!userId.equals(message.getUser().getId())) {
             throw new Exception400("해당 유저의 쪽지가 아닙니다.");
         }
+
         messageRepository.deleteById(messageId);
     }
+
+    public void userCheck(Long userId, Long opponentId) {
+        if (userId.equals(opponentId)) {
+            throw new Exception400("본인과 쪽지 대화를 할 수 없습니다.");
+        }
+    }
+
+    public User getUser(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new Exception404("존재하지 않는 유저입니다."));
+        return user;
+    }
+
+
 }

--- a/src/main/java/com/bungaebowling/server/post/Post.java
+++ b/src/main/java/com/bungaebowling/server/post/Post.java
@@ -103,12 +103,11 @@ public class Post {
         return this.user.getId().equals(userId);
     }
 
-    public void update(String newTitle, String newContent, LocalDateTime newStartTime, LocalDateTime newDueTime, Boolean newIsClose, LocalDateTime editedAt) { // 게시글 업데이트할 때 쓸 것
+    public void update(String newTitle, String newContent, LocalDateTime newStartTime, LocalDateTime newDueTime, LocalDateTime editedAt) { // 게시글 업데이트할 때 쓸 것
         this.title = newTitle;
         this.content = newContent;
         this.startTime = newStartTime;
         this.dueTime = newDueTime;
-        this.isClose = newIsClose;
         this.editedAt = editedAt;
     }
 

--- a/src/main/java/com/bungaebowling/server/post/controller/PostController.java
+++ b/src/main/java/com/bungaebowling/server/post/controller/PostController.java
@@ -3,23 +3,16 @@ package com.bungaebowling.server.post.controller;
 import com.bungaebowling.server._core.security.CustomUserDetails;
 import com.bungaebowling.server._core.utils.ApiUtils;
 import com.bungaebowling.server._core.utils.CursorRequest;
-import com.bungaebowling.server.post.Post;
 import com.bungaebowling.server.post.dto.PostRequest;
 import com.bungaebowling.server.post.dto.PostResponse;
 import com.bungaebowling.server.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -51,77 +44,15 @@ public class PostController {
     }
 
     @GetMapping("/users/{userId}/participation-records")
-    public ResponseEntity<?> getUserParticipationRecords(@PathVariable Long userId) {
-        CursorRequest cursorRequest = new CursorRequest(1L, 20);
-        List<PostResponse.GetParticipationRecordsDto.PostDto> postDtos = new ArrayList<>();
-        var postDto1 = new PostResponse.GetParticipationRecordsDto.PostDto(
-                1L,
-                "오늘 7시에 부산대 락볼링장에서 게임하실분~~",
-                LocalDateTime.now(),
-                "부산광역시 금정구 장전2동",
-                LocalDateTime.now(),
-                2,
-                false,
-                List.of(),
-                List.of(
-                        new PostResponse.GetParticipationRecordsDto.PostDto.MemberDto(
-                                2L,
-                                "최볼링",
-                                "/images/2.jpg",
-                                true
-                        ),
-                        new PostResponse.GetParticipationRecordsDto.PostDto.MemberDto(
-                                3L,
-                                "이볼링",
-                                "/images/3.jpg",
-                                false
-                        )
-                )
-        );
-        postDtos.add(postDto1);
-
-        var postDto2 = new PostResponse.GetParticipationRecordsDto.PostDto(
-                1L,
-                "오늘 당장 나올 사람!",
-                LocalDateTime.now(),
-                "부산광역시 금정구 장전2동",
-                LocalDateTime.now(),
-                2,
-                false,
-                List.of(
-                        new PostResponse.GetParticipationRecordsDto.PostDto.ScoreDto(
-                                1L,
-                                180,
-                                "/score-images/1.jpg"
-                        ),
-                        new PostResponse.GetParticipationRecordsDto.PostDto.ScoreDto(
-                                2L,
-                                210,
-                                null
-                        )
-                ),
-                List.of(
-                        new PostResponse.GetParticipationRecordsDto.PostDto.MemberDto(
-                                2L,
-                                "최볼링",
-                                "/images/2.jpg",
-                                true
-                        ),
-                        new PostResponse.GetParticipationRecordsDto.PostDto.MemberDto(
-                                3L,
-                                "이볼링",
-                                "/images/3.jpg",
-                                false
-                        )
-                )
-        );
-        postDtos.add(postDto2);
-
-        var getPostsDto = new PostResponse.GetParticipationRecordsDto(cursorRequest, postDtos);
-
-        var response = ApiUtils.success(getPostsDto);
-
-        return ResponseEntity.ok().body(response);
+    public ResponseEntity<?> getUserParticipationRecords(
+            CursorRequest cursorRequest, @PathVariable Long userId,
+            @RequestParam(value = "condition", required = false, defaultValue = "all") String condition,
+            @RequestParam(value = "status", required = false, defaultValue = "all") String status,
+            @RequestParam(value = "cityId", required = false) Long cityId,
+            @RequestParam(value = "start", required = false) String start,
+            @RequestParam(value = "end", required = false) String end) {
+        var response = postService.getParticipationRecords(cursorRequest, userId, condition, status, cityId, start, end);
+        return ResponseEntity.ok().body(ApiUtils.success(response));
     }
 
     // ToDo : 모집글 등록 response에 모집글 id 반환하기
@@ -131,7 +62,7 @@ public class PostController {
             @RequestBody @Valid PostRequest.CreatePostDto request,
             Errors errors
     ) {
-        PostResponse.GetPostPostDto response = postService.create(userDetails.getId(), request);
+        PostResponse.GetPostPostDto response = postService.createPostWithApplicant(userDetails.getId(), request);
 
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }

--- a/src/main/java/com/bungaebowling/server/post/dto/PostRequest.java
+++ b/src/main/java/com/bungaebowling/server/post/dto/PostRequest.java
@@ -52,8 +52,7 @@ public class PostRequest {
             LocalDateTime dueTime,
 
             @NotBlank(message = "모집글 내용은 필수 입력 사항입니다.")
-            String content,
-            Boolean isClose
+            String content
     ) {
     }
 

--- a/src/main/java/com/bungaebowling/server/post/repository/PostRepository.java
+++ b/src/main/java/com/bungaebowling/server/post/repository/PostRepository.java
@@ -1,8 +1,11 @@
 package com.bungaebowling.server.post.repository;
 
 import com.bungaebowling.server.post.Post;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -11,7 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificationExecutor<Post> {
 
     //ToDo: 마감시간이 현재시간보다 앞일때 AND 연산 추가하기
     @Query("SELECT p " +
@@ -114,4 +117,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "JOIN FETCH p.user u JOIN FETCH p.district d JOIN FETCH d.country c JOIN FETCH c.city ci " +
             "WHERE p.isClose = FALSE AND p.dueTime > CURRENT_TIMESTAMP AND p.id < :key ORDER BY p.id DESC")
     List<Post> findAllByIdLessThanWithCloseFalseOrderByIdDesc(@Param("key") Long key, Pageable pageable);
+
+    Page<Post> findAll(Specification<Post> spec, Pageable pageable);
 }

--- a/src/main/java/com/bungaebowling/server/post/service/PostService.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostService.java
@@ -152,7 +152,6 @@ public class PostService {
                 request.content(),
                 request.startTime(),
                 request.dueTime(),
-                request.isClose(),
                 editedAt
         );
 

--- a/src/main/java/com/bungaebowling/server/post/service/PostService.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostService.java
@@ -3,23 +3,35 @@ package com.bungaebowling.server.post.service;
 import com.bungaebowling.server._core.errors.exception.client.Exception403;
 import com.bungaebowling.server._core.errors.exception.client.Exception404;
 import com.bungaebowling.server._core.utils.CursorRequest;
+import com.bungaebowling.server.applicant.Applicant;
+import com.bungaebowling.server.applicant.repository.ApplicantRepository;
 import com.bungaebowling.server.city.country.district.District;
 import com.bungaebowling.server.city.country.district.repository.DistrictRepository;
 import com.bungaebowling.server.post.Post;
 import com.bungaebowling.server.post.dto.PostRequest;
 import com.bungaebowling.server.post.dto.PostResponse;
 import com.bungaebowling.server.post.repository.PostRepository;
+import com.bungaebowling.server.score.Score;
+import com.bungaebowling.server.score.repository.ScoreRepository;
 import com.bungaebowling.server.user.User;
+import com.bungaebowling.server.user.rate.UserRate;
+import com.bungaebowling.server.user.rate.repository.UserRateRepository;
 import com.bungaebowling.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import static com.bungaebowling.server.post.service.PostSpecification.*;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -29,29 +41,45 @@ public class PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final DistrictRepository districtRepository;
+    private final ScoreRepository scoreRepository;
+    private final ApplicantRepository applicantRepository;
+    private final UserRateRepository userRateRepository;
 
     public static final int DEFAULT_SIZE = 20;
 
     @Transactional
-    public PostResponse.GetPostPostDto create(Long userId, PostRequest.CreatePostDto request) {
+    public PostResponse.GetPostPostDto createPostWithApplicant(Long userId, PostRequest.CreatePostDto request) {
 
         User user = findUserById(userId);
 
         Long districtId = request.districtId();
+        
+        var savedPost = savePost(user, districtId, request);
 
-        return savePost(user, districtId, request); // 저장로직 따로 분리
+        saveApplicant(savedPost, user);
+
+        return new PostResponse.GetPostPostDto(savedPost.getId());
 
     }
 
-    private PostResponse.GetPostPostDto savePost(User user, Long districtId, PostRequest.CreatePostDto request) { // 저장로직 따로 분리
+    private Post savePost(User user, Long districtId, PostRequest.CreatePostDto request) {
 
         District district = districtRepository.findById(districtId).orElseThrow(() -> new Exception404("존재하지 않는 행정 구역입니다."));
 
         Post post = request.toEntity(user, district);
-        Long postId = postRepository.save(post).getId();
 
-        return new PostResponse.GetPostPostDto(postId);
+        return postRepository.save(post);
 
+    }
+
+    private void saveApplicant(Post post, User user) {
+        applicantRepository.save(
+                Applicant.builder()
+                        .post(post)
+                        .user(user)
+                        .status(true)
+                        .build()
+        );
     }
 
     private User findUserById(Long userId) {
@@ -74,7 +102,7 @@ public class PostService {
 
         List<Post> posts = findPosts(cursorRequest, cityId, countryId, districtId, all);
 
-        Long lastKey = posts.isEmpty() ? CursorRequest.NONE_KEY : posts.get(posts.size() - 1).getId();
+        Long lastKey = getLastKey(posts);
 
         return PostResponse.GetPostsDto.of(cursorRequest.next(lastKey, DEFAULT_SIZE), posts);
 
@@ -143,15 +171,6 @@ public class PostService {
 
     }
 
-    private void deletePost(Post post) { // 삭제 로직 따로 분리
-        postRepository.delete(post);
-    }
-
-    private Post findById(Long postId) { // id로 post 찾는 로직 따로 분리
-        return postRepository.findById(postId)
-                .orElseThrow(() -> new Exception404("모집글을 찾을 수 없습니다."));
-    }
-
     @Transactional
     public void updateIsClose(Long userId, Long postId, PostRequest.UpdatePostIsCloseDto request) {
         Post post = findById(postId);
@@ -161,6 +180,98 @@ public class PostService {
         }
 
         post.updateIsClose(request.isClose());
+    }
+
+    public PostResponse.GetParticipationRecordsDto getParticipationRecords(CursorRequest cursorRequest, Long userId,
+                                                                           String condition, String status, Long cityId, String start, String end) {
+        List<Post> posts = loadPosts(cursorRequest, userId, condition, status, cityId, start, end);
+
+        Map<Long, List<Score>> scoreMap = getScoreMap(userId, posts);
+        Map<Long, List<Applicant>> applicantMap = getApplicantMap(posts);
+        Map<Long, List<User>> memberMap = getMemberMap(userId, posts, applicantMap);
+        Map<Long, List<UserRate>> rateMap = getRateMap(userId, posts, applicantMap);
+        Map<Long, Long> applicantIdMap = getApplicantIdMap(userId, posts, applicantMap);
+
+        Long lastKey = getLastKey(posts);
+        return PostResponse.GetParticipationRecordsDto.of(cursorRequest.next(lastKey, DEFAULT_SIZE), posts, scoreMap, memberMap, rateMap, applicantIdMap);
+    }
+
+    private List<Post> loadPosts(CursorRequest cursorRequest, Long userId, String condition, String status, Long cityId, String start, String end) {
+        int size = cursorRequest.hasSize() ? cursorRequest.size() : DEFAULT_SIZE;
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Order.desc("id")));
+
+        Specification<Post> spec = Specification.where(conditionEqual(condition, userId))
+                .and(statusEqual(status))
+                .and(cityIdEqual(cityId))
+                .and(createdAtBetween(start, end));
+
+        if(cursorRequest.hasKey()){
+            spec = spec.and(postIdLessThan(cursorRequest.key()));
+        }
+        return postRepository.findAll(spec, pageable).getContent();
+    }
+
+    private Map<Long, List<Applicant>> getApplicantMap(List<Post> posts) {
+        return posts.stream().collect(Collectors.toMap(
+                Post::getId,
+                post -> applicantRepository.findAllByPostIdAndStatusTrueOrderByUserIdDesc(post.getId())
+        ));
+    }
+
+    private Map<Long, List<Score>> getScoreMap(Long userId, List<Post> posts) {
+        return posts.stream().collect(Collectors.toMap(
+                Post::getId,
+                post -> scoreRepository.findAllByUserIdAndPostIdOrderById(userId, post.getId())
+        ));
+    }
+
+    private Map<Long, Long> getApplicantIdMap(Long userId, List<Post> posts, Map<Long, List<Applicant>> applicantMap) {
+        return posts.stream().collect(Collectors.toMap(
+                Post::getId,
+                post -> applicantMap.get(post.getId()).stream()
+                        .filter(applicant -> userId.equals(applicant.getUser().getId()))
+                        .map(Applicant::getId)
+                        .findFirst()
+                        .orElseThrow(() -> new Exception404("존재하지 않는 신청입니다."))
+        ));
+    }
+
+    private Map<Long, List<User>> getMemberMap(Long userId, List<Post> posts, Map<Long, List<Applicant>> applicantMap) {
+        return posts.stream().collect(Collectors.toMap(
+                Post::getId,
+                post -> applicantMap.get(post.getId()).stream()
+                        .map(Applicant::getUser)
+                        .filter(user -> !user.getId().equals(userId))
+                        .toList()
+        ));
+    }
+
+    private Map<Long, List<UserRate>> getRateMap(Long userId, List<Post> posts, Map<Long, List<Applicant>> applicantMap) {
+        return posts.stream().collect(Collectors.toMap(
+                Post::getId,
+                post -> {
+                    List<UserRate> userRates = new ArrayList<>();
+                    applicantMap.get(post.getId()).stream()
+                            .filter(applicant -> applicant.getUser().getId().equals(userId))
+                            .forEach(applicant ->
+                                    userRates.addAll(userRateRepository.findAllByApplicantId(applicant.getId()))
+                            );
+                    return userRates;
+                }
+        ));
+    }
+
+    private void deletePost(Post post) { // 삭제 로직 따로 분리
+        postRepository.delete(post);
+    }
+
+    private Post findById(Long postId) { // id로 post 찾는 로직 따로 분리
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new Exception404("모집글을 찾을 수 없습니다."));
+    }
+
+    private static Long getLastKey(List<Post> posts) {
+        return posts.isEmpty() ? CursorRequest.NONE_KEY : posts.get(posts.size() - 1).getId();
     }
 
 }

--- a/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
@@ -1,0 +1,80 @@
+package com.bungaebowling.server.post.service;
+
+import com.bungaebowling.server.applicant.Applicant;
+import com.bungaebowling.server.city.country.Country;
+import com.bungaebowling.server.city.country.district.District;
+import com.bungaebowling.server.post.Post;
+import com.bungaebowling.server.user.User;
+import jakarta.persistence.criteria.Fetch;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class PostSpecification {
+
+    public static final LocalDateTime START_TIME = LocalDateTime.now().minusMonths(3);
+    public static final LocalDateTime END_TIME = LocalDateTime.now();
+
+    public static Specification<Post> conditionEqual(String condition, Long userId) {
+        return (root, query, criteriaBuilder) -> {
+            Join<Post, User> userJoin = root.join("user", JoinType.LEFT);
+            Join<Post, Applicant> applicantJoin = root.join("applicants", JoinType.LEFT);
+            Join<Applicant, User> applicantUserJoin = applicantJoin.join("user", JoinType.LEFT);
+            Fetch<Post, District> districtFetch = root.fetch("district", JoinType.LEFT);
+            Fetch<District, Country> countryFetch = districtFetch.fetch("country", JoinType.LEFT);
+            countryFetch.fetch("city", JoinType.LEFT);
+            root.fetch("applicants", JoinType.LEFT);
+
+            Predicate createdPredicate = criteriaBuilder.equal(userJoin.get("id"), userId);
+            Predicate participatedPredicate = criteriaBuilder.and(
+                    criteriaBuilder.isTrue(applicantJoin.get("status")),
+                    criteriaBuilder.equal(applicantUserJoin.get("id"), userId),
+                    criteriaBuilder.notEqual(userJoin.get("id"), userId)
+            );
+
+            return switch (condition) {
+                case "created" -> createdPredicate;
+                case "participated" -> participatedPredicate;
+                default -> criteriaBuilder.or(createdPredicate, participatedPredicate);
+            };
+        };
+    }
+
+    public static Specification<Post> statusEqual(String status) {
+        return (root, query, criteriaBuilder) -> switch (status) {
+            case "open" -> criteriaBuilder.equal(root.get("isClose"), false);
+            case "closed" -> criteriaBuilder.equal(root.get("isClose"), true);
+            default -> criteriaBuilder.conjunction();
+        };
+    }
+
+    public static Specification<Post> cityIdEqual(Long cityId) {
+        return (root, query, criteriaBuilder) -> {
+            if (cityId != null) {
+                return criteriaBuilder.equal(
+                        root.join("district").join("country").join("city").get("id"),
+                        cityId
+                );
+            }
+            return criteriaBuilder.conjunction();
+        };
+    }
+
+    public static Specification<Post> createdAtBetween(String start, String end) {
+        return (root, query, criteriaBuilder) -> {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            LocalDateTime startDate = start == null ? START_TIME : LocalDate.parse(start, formatter).atStartOfDay();
+            LocalDateTime endDate = end == null ? END_TIME : LocalDate.parse(end, formatter).plusDays(1).atStartOfDay();
+            return criteriaBuilder.between(root.get("startTime"), startDate, endDate);
+        };
+    }
+
+    public static Specification<Post> postIdLessThan(Long postId) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.lessThan(root.get("postId"), postId);
+    }
+}

--- a/src/main/java/com/bungaebowling/server/score/Score.java
+++ b/src/main/java/com/bungaebowling/server/score/Score.java
@@ -35,16 +35,13 @@ public class Score {
     @Range(min = 0, max = 300, message = "점수는 0~300까지의 수만 입력 가능합니다.")
     private Integer scoreNum;
 
-    @Column(name = "result_image_url")
     private String resultImageUrl;
 
-    @Column(name = "created_at")
     @Temporal(TemporalType.TIMESTAMP)
     @ColumnDefault(value = "now()")
     private LocalDateTime createdAt;
 
     // 브라우저 상의 이미지 접근 경로
-    @Column(name = "access_image_url")
     private String accessImageUrl;
 
     @Builder
@@ -57,10 +54,15 @@ public class Score {
         this.accessImageUrl = accessImageUrl;
     }
 
-    public void update(Integer scoreNum, String resultImageUrl, LocalDateTime updatedAt, String accessImageUrl){
+    public void updateWithFile(Integer scoreNum, String resultImageUrl, LocalDateTime updatedAt, String accessImageUrl){
         this.scoreNum = scoreNum;
         this.resultImageUrl = resultImageUrl;
         this.createdAt = updatedAt;
         this.accessImageUrl = accessImageUrl;
+    }
+
+    public void updateWithoutFile(Integer scoreNum, LocalDateTime updatedAt){
+        this.scoreNum = scoreNum;
+        this.createdAt = updatedAt;
     }
 }

--- a/src/main/java/com/bungaebowling/server/score/controller/ScoreController.java
+++ b/src/main/java/com/bungaebowling/server/score/controller/ScoreController.java
@@ -10,8 +10,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/posts")
@@ -31,10 +29,10 @@ public class ScoreController {
     public ResponseEntity<?> createScore(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId,
-            @RequestParam(name = "scores") List<Integer> scoreNums,
-            @RequestParam(name = "images") List<MultipartFile> images
+            @RequestParam(name = "score") Integer scoreNum,
+            @RequestParam(name = "image", required = false) MultipartFile image
     ) {
-        scoreService.create(userDetails.getId(), postId, scoreNums, images);
+        scoreService.create(userDetails.getId(), postId, scoreNum, image);
 
         return ResponseEntity.ok().body(ApiUtils.success());
     }
@@ -45,7 +43,7 @@ public class ScoreController {
             @PathVariable Long postId,
             @PathVariable Long scoreId,
             @RequestParam(name = "score") Integer scoreNum,
-            @RequestParam(name = "image") MultipartFile image
+            @RequestParam(name = "image", required = false) MultipartFile image
     ) {
         scoreService.update(userDetails.getId(), postId, scoreId, scoreNum, image);
 

--- a/src/main/java/com/bungaebowling/server/score/repository/ScoreRepository.java
+++ b/src/main/java/com/bungaebowling/server/score/repository/ScoreRepository.java
@@ -2,6 +2,8 @@ package com.bungaebowling.server.score.repository;
 
 import com.bungaebowling.server.score.Score;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,9 @@ import java.util.List;
 @Repository
 public interface ScoreRepository extends JpaRepository<Score, Long> {
     List<Score> findAllByPostId(Long postId);
+
+    List<Score> findAllByUserId(Long userId);
+
+    @Query("SELECT s FROM Score s JOIN FETCH s.user u WHERE u.id = :userId and s.post.id = :postId ORDER BY s.id ASC")
+    List<Score> findAllByUserIdAndPostIdOrderById(@Param("userId") Long userId, @Param("postId") Long postId);
 }

--- a/src/main/java/com/bungaebowling/server/user/User.java
+++ b/src/main/java/com/bungaebowling/server/user/User.java
@@ -1,15 +1,16 @@
 package com.bungaebowling.server.user;
 
 import com.bungaebowling.server.city.country.district.District;
-import com.bungaebowling.server.user.rate.UserRate;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -36,6 +37,9 @@ public class User {
     @Column(length = 200)
     private String imgUrl;
 
+    @Column(length = 200)
+    private String resultImageUrl;
+
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'ROLE_PENDING'")
     @Column(length = 50)
@@ -58,5 +62,18 @@ public class User {
 
     public void updateRole(Role role) {
         this.role = role;
+    }
+
+    public void updateProfile(String name, District district, String resultImageUrl, String accessImageUrl){
+        this.name = Objects.nonNull(name) ? name : this.name;
+        this.district = Objects.nonNull(district) ? district : this.district;
+        this.imgUrl = Objects.nonNull(accessImageUrl) ? accessImageUrl : this.imgUrl;
+        this.resultImageUrl = Objects.nonNull(resultImageUrl) ? resultImageUrl : this.resultImageUrl;
+    }
+
+    public String getDistrictName() {
+        return this.district.getCountry().getCity().getName() + " " +
+                this.district.getCountry().getName() + " "  +
+                this.district.getName();
     }
 }

--- a/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
@@ -17,6 +17,7 @@ public class UserRequest {
 
     public record JoinDto(
             @Size(max = 20, message = "최대 20자까지 입니다.")
+            @Pattern(regexp = "[a-zA-Z0-9가-힣]*", message = "한글, 영문, 숫자만 입력 가능합니다.")
             String name,
             @NotEmpty @Size(max = 100, message = "최대 100자까지 입니다.")
             @Pattern(regexp = "^[\\w.%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$", message = "이메일 형식이 아닙니다.")
@@ -41,4 +42,11 @@ public class UserRequest {
             @NotEmpty
             String token
     ) {}
+
+    public record UpdateMyProfileDto(
+            @Size(max = 20, message = "최대 20자까지 입니다.")
+            @Pattern(regexp = "[a-zA-Z0-9가-힣]*", message = "한글, 영문, 숫자만 입력 가능합니다.")
+            String name,
+            Long districtId
+    ){}
 }

--- a/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
@@ -1,8 +1,11 @@
 package com.bungaebowling.server.user.dto;
 
 import com.bungaebowling.server._core.utils.CursorRequest;
+import com.bungaebowling.server.user.Role;
+import com.bungaebowling.server.user.User;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 public class UserResponse {
 
@@ -10,13 +13,28 @@ public class UserResponse {
             CursorRequest nextCursorRequest,
             List<UserDto> users
     ) {
+        public static GetUsersDto of(CursorRequest nextCursorRequest, List<User> users,
+                                     List<Double> ratings) {
+            return new GetUsersDto(
+                    nextCursorRequest,
+                    IntStream.range(0, users.size())
+                            .mapToObj(index -> new UserDto(users.get(index), ratings.get(index))).toList());
+        }
+
         public record UserDto(
                 Long id,
                 String name,
                 Double rating,
                 String profileImage
         ) {
-
+            public UserDto(User user, Double rating){
+                this(
+                        user.getId(),
+                        user.getName(),
+                        rating,
+                        user.getImgUrl()
+                );
+            }
         }
     }
 
@@ -27,17 +45,50 @@ public class UserResponse {
             String address,
             String profileImage
     ){
+        public GetUserDto(User user, Double rating, Integer average) {
+            this(
+                    user.getName(),
+                    average,
+                    rating,
+                    user.getDistrictName(),
+                    user.getImgUrl()
+            );
+        }
+    }
 
+    public record GetMyProfileDto(
+            Long id,
+            String name,
+            String email,
+            Boolean verification,
+            Integer averageScore,
+            Double rating,
+            Long districtId,
+            String address,
+            String profileImage
+    ){
+        public GetMyProfileDto(User user, Double rating, Integer average) {
+            this(
+                    user.getId(),
+                    user.getName(),
+                    user.getEmail(),
+                    user.getRole() == Role.ROLE_USER,
+                    average,
+                    rating,
+                    user.getDistrict().getId(),
+                    user.getDistrictName(),
+                    user.getImgUrl()
+            );
+        }
     }
 
     public record GetRecordDto(
+            String name,
             Integer game,
             Integer average,
             Integer maximum,
             Integer minimum
-    ) {
-
-    }
+    ) {}
 
     public record JoinDto(
             Long savedId,

--- a/src/main/java/com/bungaebowling/server/user/rate/UserRate.java
+++ b/src/main/java/com/bungaebowling/server/user/rate/UserRate.java
@@ -23,13 +23,12 @@ public class UserRate {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    @JoinColumn(name = "user_id")
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "applicant_id", referencedColumnName = "id")
+    @JoinColumn(name = "applicant_id")
     private Applicant applicant;
-
 
     @Column(nullable = false)
     private Integer starCount;

--- a/src/main/java/com/bungaebowling/server/user/rate/repository/UserRateRepository.java
+++ b/src/main/java/com/bungaebowling/server/user/rate/repository/UserRateRepository.java
@@ -2,10 +2,15 @@ package com.bungaebowling.server.user.rate.repository;
 
 import com.bungaebowling.server.user.rate.UserRate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface UserRateRepository extends JpaRepository<UserRate, Long> {
 
     List<UserRate> findAllByUserId(Long userId);
+
+    @Query("SELECT ur FROM UserRate ur JOIN FETCH ur.user u WHERE ur.applicant.id = :applicantId")
+    List<UserRate> findAllByApplicantId(@Param("applicantId") Long applicantId);
 }

--- a/src/main/java/com/bungaebowling/server/user/repository/UserRepository.java
+++ b/src/main/java/com/bungaebowling/server/user/repository/UserRepository.java
@@ -1,12 +1,19 @@
 package com.bungaebowling.server.user.repository;
 
 import com.bungaebowling.server.user.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByName(String name);
+
+    List<User> findAllByNameContainingOrderByIdDesc(@Param("name")String name, Pageable pageable);
+
+    List<User> findAllByNameContainingAndIdLessThanOrderByIdDesc(@Param("name")String name, @Param("key") Long key, Pageable pageable);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4740,6 +4740,9 @@ VALUES ('김볼링', 'test@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb
 INSERT INTO post_tb (title, user_id, district_id, start_time, due_time, content)
 VALUES ('불금 볼링 점수 내기 하실 분~', 1, 1, '2023-12-01', '2023-11-29', '볼링 점수 내기합시다.');
 
+INSERT INTO applicant_tb (status, user_id, post_id)
+VALUES (true, 1, 1);
+
 INSERT INTO comment_tb (post_id, user_id, parent_id, content)
 VALUES (1, 2, null, '저 해도 되나요?'),
        (1, 1, 1, '신청해주세요~');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4735,14 +4735,115 @@ VALUES
 -- 비밀번호는 test12!@
 INSERT INTO user_tb (name, email, password, district_id, role)
 VALUES ('김볼링', 'test@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
-       ('볼링볼링', 'test1@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
+       ('볼링볼링', 'test1@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('박볼', 'test3@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링링', 'test4@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('볼링링', 'test5@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼', 'test6@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링륑', 'test7@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('주주', 'test8@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('son', 'test9@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼2', 'test10@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('볼링링1', 'test11@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('볼스', 'test12@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링2', 'test13@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링3', 'test14@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링4', 'test15@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링5', 'test16@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링6', 'test17@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링7', 'test18@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링8', 'test19@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링9', 'test20@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링10', 'test21@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링11', 'test22@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링12', 'test23@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링13', 'test24@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링14', 'test25@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('김볼링링15', 'test26@test.net', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
 
-INSERT INTO post_tb (title, user_id, district_id, start_time, due_time, content)
-VALUES ('불금 볼링 점수 내기 하실 분~', 1, 1, '2023-12-01', '2023-11-29', '볼링 점수 내기합시다.');
+INSERT INTO post_tb (title, user_id, district_id, start_time, due_time, content, is_close)
+VALUES ('불금 볼링 점수 내기 하실 분~', 1, 1, '2023-12-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 1, 469, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 1, 469, '2023-09-08', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 1, 469, '2023-09-08', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 1, 469, '2023-08-05', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 3, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 4, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 4, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 4, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 2, 1, '2023-09-01', '2023-11-29', '볼링 점수 내기합시다.', false),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-10-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 3, 1, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-10-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true),
+       ('불금 볼링 점수 내기 하실 분~', 4, 469, '2023-08-01', '2023-11-29', '볼링 점수 내기합시다.', true);
 
-INSERT INTO applicant_tb (status, user_id, post_id)
-VALUES (true, 1, 1);
+INSERT INTO applicant_tb (user_id, post_id, status)
+VALUES (1, 1, true),
+       (1, 2, true),
+       (1, 3, true),
+       (1, 4, true),
+       (1, 5, true),
+       (2, 6, true),
+       (2, 7, true),
+       (2, 8, true),
+       (2, 9, true),
+       (2, 10, true),
+       (3, 11, true),
+       (3, 12, true),
+       (3, 13, true),
+       (3, 14, true),
+       (3, 15, true),
+       (4, 16, true),
+       (4, 17, true),
+       (4, 18, true),
+       (4, 19, true),
+       (4, 20, true),
+       -- 여기까지 자신의 모집글에 자동 신청
+       (1, 6, true),
+       (1, 7, false),
+       (1, 8, false),
+       (1, 9, false),
+       (1, 10, false),
+       (1, 11, false),
+       (1, 12, false),
+       (1, 13, false),
+       (1, 14, false),
+       (1, 15, false),
+       (1, 16, true),
+       (1, 17, true),
+       (1, 18, true),
+       (1, 19, true),
+       (1, 20, true),
+       (2, 1, true),
+       (3, 2, true),
+       (4, 1, true),
+       (5, 1, true),
+       (11, 6, true),
+       (7, 6, true),
+       (8, 6, true),
+       (9, 6, true),
+       (10, 6, true);
 
 INSERT INTO comment_tb (post_id, user_id, parent_id, content)
 VALUES (1, 2, null, '저 해도 되나요?'),
        (1, 1, 1, '신청해주세요~');
+
+INSERT INTO score_tb (user_id, post_id, score_num)
+VALUES (1, 6, 100),
+       (1, 1, 150),
+       (1, 6, 45);
+
+INSERT INTO user_rate_tb(applicant_id, user_id, star_count)
+VALUES (1, 2, 5),
+       (1, 4, 5),
+       (1, 5, 5),
+       (20, 1, 5),
+       (19, 1, 5),
+       (18, 1, 4),
+       (17, 1, 1);

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -1,13 +1,14 @@
 CREATE TABLE user_tb
 (
-    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
-    name        VARCHAR(20)  NOT NULL UNIQUE,
-    email       VARCHAR(100) NOT NULL UNIQUE,
-    password    VARCHAR(100) NOT NULL,
-    district_id BIGINT       NOT NULL,
-    img_url     VARCHAR(200),
-    role        VARCHAR(50) DEFAULT 'ROLE_PENDING' CHECK (role IN ('ROLE_PENDING', 'ROLE_USER')),
-    created_at  TIMESTAMP   DEFAULT now()
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name             VARCHAR(20)  NOT NULL UNIQUE,
+    email            VARCHAR(100) NOT NULL UNIQUE,
+    password         VARCHAR(100) NOT NULL,
+    district_id      BIGINT       NOT NULL,
+    img_url          VARCHAR(200),
+    result_image_url VARCHAR(200),
+    role             VARCHAR(50) DEFAULT 'ROLE_PENDING' CHECK (role IN ('ROLE_PENDING', 'ROLE_USER')),
+    created_at       TIMESTAMP   DEFAULT now()
 );
 
 CREATE TABLE post_tb
@@ -51,7 +52,7 @@ CREATE TABLE score_tb
     id               BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id          BIGINT NOT NULL,
     post_id          BIGINT NOT NULL,
-    score_num            INT    NOT NULL,
+    score_num        INT    NOT NULL,
     result_image_url VARCHAR(100),
     access_image_url VARCHAR(200),
     created_at       TIMESTAMP DEFAULT now()

--- a/src/test/java/com/bungaebowling/server/message/MessageRepositoryTest.java
+++ b/src/test/java/com/bungaebowling/server/message/MessageRepositoryTest.java
@@ -1,4 +1,5 @@
 package com.bungaebowling.server.message;
+
 import com.bungaebowling.server.city.country.district.District;
 import com.bungaebowling.server.city.country.district.repository.DistrictRepository;
 import com.bungaebowling.server.message.repository.MessageRepository;
@@ -15,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Pageable;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -187,34 +189,6 @@ class MessageRepositoryTest {
         Assertions.assertThat(messages.get(1).getOpponentUser().getImgUrl()).isEqualTo("testimage1");
     }
 
-    @Test
-    @DisplayName("새로운 쪽지 갯수 조회")
-    void countByUserIdAndIsReceiveTrueAndIsReadFalse() {
-        //given
-        User testuser = userRepository.findByName("테스트유저3").get();
-        List<Message> messages = messageRepository.findAllByUserId(testuser.getId());
-        messages.get(0).read();
-        em.flush();
-        //when
-        System.out.println("====================start===================");
-        Long count = messageRepository.countByUserIdAndIsReceiveTrueAndIsReadFalse(testuser.getId());
-        System.out.println("========================end=====================");
-        //then
-        Assertions.assertThat(count).isEqualTo(19);
-    }
-
-    @Test
-    @DisplayName("전체 쪽지 갯수 조회")
-    void countByUserIdAndIsReceiveTrue() {
-        //given
-        User testuser = userRepository.findByName("테스트유저3").get();
-        //when
-        System.out.println("====================start===================");
-        Long count = messageRepository.countByUserIdAndIsReceiveTrue(testuser.getId());
-        System.out.println("========================end=====================");
-        //then
-        Assertions.assertThat(count).isEqualTo(20);
-    }
 
     @Test
     @DisplayName("일대일 대화방 쪽지 조회")


### PR DESCRIPTION
## Summary

6주차 개발 내역을 정리하여 병합합니다.

## Description

- 프로필 관련 API를 구현하였습니다.
- 유저 레코드 API를 구현하였습니다.
- 참여기록 조회 API를 구현하였습니다.
  - 동적 쿼리를 위해 jpa specification으로 구현하였습니다.
  - 기간별 검색은 yyyy-mm-dd형태의 string으로 qeury로 받습니다.
  - 타 참여자에게 별점 평가 api를 위해 response로 자신의 신청ID를 포함하여 주도록 하였습니다.
- 신청 여부 API를 구현하였습니다.
- 볼링 점수(score) 등록 API를 개선하였습니다.
  - 기존 다중 업로드 방식에서 단일 업로드 방식으로 수정하였습니다.
  - 점수 이미지를 필수가 아니게 변경하였습니다.
- 쪽지 API를 개선하였습니다.
  - 대화방 목록에서 새로운 쪽지의 수를 알려줍니다.
  - 새로운 쪽지의 수를 사용하여 새로운 쪽지 수 + 10 만큼 쪽지 조회 api를 호출하게 됩니다.
  - 불필요한 countAll과 countNew 정보를 삭제하였습니다.
- 별점 등록 api를 구현하였습니다.
  - 자신의 신청id로 같이 참여한 유저에게 1 ~ 5의 별점을 남길 수 있습니다.
