### PR TITLE
참여 기록 조회, 신청자 목록 버그 수정

### DIFF
--- a/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
+++ b/src/main/java/com/bungaebowling/server/applicant/dto/ApplicantResponse.java
@@ -11,15 +11,13 @@ public class ApplicantResponse {
 
     public record GetApplicantsDto(
             CursorRequest nextCursorRequest,
-            Long participantNumber,
-            Long currentNumber,
+            Long applicantNumber,
             List<ApplicantDto> applicants
     ) {
-        public static GetApplicantsDto of(CursorRequest nextCursorRequest, Long participantNumber, Long currentNumber, List<Applicant> applicants, List<Double> ratings){
+        public static GetApplicantsDto of(CursorRequest nextCursorRequest, Long applicantNumber, List<Applicant> applicants, List<Double> ratings) {
             return new GetApplicantsDto(
                     nextCursorRequest,
-                    participantNumber,
-                    currentNumber,
+                    applicantNumber,
                     IntStream.range(0, applicants.size())
                             .mapToObj(index -> new ApplicantDto(applicants.get(index), ratings.get(index))).toList()
             );

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -22,11 +22,11 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     @Query("SELECT a FROM Applicant a JOIN FETCH a.user u WHERE a.post.id = :postId AND u.id != :userId AND a.id < :key ORDER BY a.id DESC")
     List<Applicant> findAllByPostIdAndUserIdNotLessThanOrderByIdDesc(@Param("key") Long key, @Param("postId") Long postId, @Param("userId") Long userId, Pageable pageable);
 
-    @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId AND a.status = true")
-    Long countByPostIdAndIsStatusTrue(@Param("postId") Long postId);
+    @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId AND a.user.id != :userId AND a.status = true")
+    Long countByPostIdAndUserIdNotAndIsStatusTrue(@Param("postId") Long postId, @Param("userId") Long userId);
 
-    @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId")
-    Long countByPostId(@Param("postId") Long postId);
+    @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId AND a.user.id != :userId")
+    Long countByPostId(@Param("postId") Long postId, @Param("userId") Long userId);
 
     @Query("SELECT a FROM Applicant a JOIN FETCH a.post p WHERE a.id = :id")
     Optional<Applicant> findByIdJoinFetchPost(@Param("id") Long id);

--- a/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/bungaebowling/server/applicant/repository/ApplicantRepository.java
@@ -26,7 +26,7 @@ public interface ApplicantRepository extends JpaRepository<Applicant, Long> {
     Long countByPostIdAndUserIdNotAndIsStatusTrue(@Param("postId") Long postId, @Param("userId") Long userId);
 
     @Query("SELECT count(a) FROM Applicant a WHERE a.post.id = :postId AND a.user.id != :userId")
-    Long countByPostId(@Param("postId") Long postId, @Param("userId") Long userId);
+    Long countByPostIdAndUserIdNot(@Param("postId") Long postId, @Param("userId") Long userId);
 
     @Query("SELECT a FROM Applicant a JOIN FETCH a.post p WHERE a.id = :id")
     Optional<Applicant> findByIdJoinFetchPost(@Param("id") Long id);

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -43,7 +43,7 @@ public class ApplicantService {
         if (!isMatchedUser(userId, post))
             throw new Exception403("자신의 모집글이 아닙니다.");
 
-        Long participantNumber = applicantRepository.countByPostId(post.getId(), userId);
+        Long participantNumber = applicantRepository.countByPostIdAndUserIdNot(post.getId(), userId);
         Long currentNumber = applicantRepository.countByPostIdAndUserIdNotAndIsStatusTrue(post.getId(), userId);
         List<Applicant> applicants = loadApplicants(cursorRequest, post.getId(), userId);
         Long lastKey = getLastKey(applicants);

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -43,16 +43,16 @@ public class ApplicantService {
         if (!isMatchedUser(userId, post))
             throw new Exception403("자신의 모집글이 아닙니다.");
 
-        Long participantNumber = applicantRepository.countByPostId(post.getId());
-        Long currentNumber = applicantRepository.countByPostIdAndIsStatusTrue(post.getId());
+        Long participantNumber = applicantRepository.countByPostId(post.getId(), userId);
+        Long currentNumber = applicantRepository.countByPostIdAndUserIdNotAndIsStatusTrue(post.getId(), userId);
         List<Applicant> applicants = loadApplicants(cursorRequest, post.getId(), userId);
         Long lastKey = getLastKey(applicants);
 
         var ratings = applicants.stream().map(applicant ->
-                     userRateRepository.findAllByUserId(applicant.getUser().getId()).stream()
-                            .mapToInt(UserRate::getStarCount)
-                            .average().orElse(0.0)
-                ).toList();
+                userRateRepository.findAllByUserId(applicant.getUser().getId()).stream()
+                        .mapToInt(UserRate::getStarCount)
+                        .average().orElse(0.0)
+        ).toList();
 
         return ApplicantResponse.GetApplicantsDto.of(
                 cursorRequest.next(lastKey, DEFAULT_SIZE),

--- a/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
+++ b/src/main/java/com/bungaebowling/server/applicant/service/ApplicantService.java
@@ -43,8 +43,7 @@ public class ApplicantService {
         if (!isMatchedUser(userId, post))
             throw new Exception403("자신의 모집글이 아닙니다.");
 
-        Long participantNumber = applicantRepository.countByPostIdAndUserIdNot(post.getId(), userId);
-        Long currentNumber = applicantRepository.countByPostIdAndUserIdNotAndIsStatusTrue(post.getId(), userId);
+        Long applicantNumber = applicantRepository.countByPostIdAndUserIdNot(post.getId(), userId);
         List<Applicant> applicants = loadApplicants(cursorRequest, post.getId(), userId);
         Long lastKey = getLastKey(applicants);
 
@@ -56,8 +55,7 @@ public class ApplicantService {
 
         return ApplicantResponse.GetApplicantsDto.of(
                 cursorRequest.next(lastKey, DEFAULT_SIZE),
-                participantNumber,
-                currentNumber,
+                applicantNumber,
                 applicants,
                 ratings);
     }

--- a/src/main/java/com/bungaebowling/server/post/Post.java
+++ b/src/main/java/com/bungaebowling/server/post/Post.java
@@ -91,7 +91,10 @@ public class Post {
     }
 
     public Long getCurrentNumber() { // 현재 모집된 사람 수
-        return applicants.stream().filter(Applicant::getStatus).count();
+        return applicants.stream()
+                .distinct()
+                .filter(Applicant::getStatus)
+                .count();
     }
 
 

--- a/src/main/java/com/bungaebowling/server/post/service/PostService.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostService.java
@@ -187,7 +187,7 @@ public class PostService {
 
         Map<Long, List<Score>> scoreMap = getScoreMap(userId, posts);
         Map<Long, List<Applicant>> applicantMap = getApplicantMap(posts);
-        Map<Long, List<User>> memberMap = getMemberMap(userId, posts, applicantMap);
+        Map<Long, List<User>> memberMap = getMemberMap(posts, applicantMap);
         Map<Long, List<UserRate>> rateMap = getRateMap(userId, posts, applicantMap);
         Map<Long, Long> applicantIdMap = getApplicantIdMap(userId, posts, applicantMap);
 
@@ -235,12 +235,11 @@ public class PostService {
         ));
     }
 
-    private Map<Long, List<User>> getMemberMap(Long userId, List<Post> posts, Map<Long, List<Applicant>> applicantMap) {
+    private Map<Long, List<User>> getMemberMap(List<Post> posts, Map<Long, List<Applicant>> applicantMap) {
         return posts.stream().collect(Collectors.toMap(
                 Post::getId,
                 post -> applicantMap.get(post.getId()).stream()
                         .map(Applicant::getUser)
-                        .filter(user -> !user.getId().equals(userId))
                         .toList()
         ));
     }

--- a/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
@@ -75,6 +75,6 @@ public class PostSpecification {
     }
 
     public static Specification<Post> postIdLessThan(Long postId) {
-        return (root, query, criteriaBuilder) -> criteriaBuilder.lessThan(root.get("postId"), postId);
+        return (root, query, criteriaBuilder) -> criteriaBuilder.lessThan(root.get("id"), postId);
     }
 }


### PR DESCRIPTION
## Summary
참여 기록 조회, 신청자 목록 버그를 수정했습니다.

## Description
- 참여 기록 조회에서 참석 확정 인원인 currentNumber를 post 엔티티에서 가져올 때, 데이터가 중복 조회되는 문제가 발생했습니다. jpql/querydsl을 사용하면 join/fetch join에서 OneToMany를 사용할 때 데이터가 중복 조회될 수 있다고 합니다!!! distinct()를 사용해서 중복을 제거했습니다. 
- 참여 기록 조회의 멤버에 참여 기록 조회 대상도 함께 넘겨줍니다.
- 참여 기록 조회에서 key 요청이 안되는 오류가 발생했습니다. 이것은 저의 실수로.. postIdLessThan()에서 id가 아닌 postId를 넘겨주고 있었습니다. 
- 신청자 목록 조회에서 글 작성자를 신청 테이블에 추가하면서 신청자 수를 가져올 때 +1 되는 버그가 발생했습니다. -1을 하기엔 좀 불안정한 것 같아서 query를 가져올 때 글 작성자일 경우를 제외하고 가져오도록 수정했습니다. 

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #59 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->