### PR TITLE
참여 기록 조회 기준 수정, post 양방향 제거

### DIFF
--- a/src/main/java/com/bungaebowling/server/post/Post.java
+++ b/src/main/java/com/bungaebowling/server/post/Post.java
@@ -1,6 +1,5 @@
 package com.bungaebowling.server.post;
 
-import com.bungaebowling.server.applicant.Applicant;
 import com.bungaebowling.server.city.country.district.District;
 import com.bungaebowling.server.user.User;
 import jakarta.persistence.*;
@@ -12,8 +11,6 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -59,9 +56,6 @@ public class Post {
     @ColumnDefault(value = "now()")
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
-    private final List<Applicant> applicants = new ArrayList<>();
-
     @Builder
     public Post(String title, User user, District district, String content, LocalDateTime startTime, LocalDateTime dueTime, Boolean isClose, int viewCount, LocalDateTime editedAt, LocalDateTime createdAt) {
         this.title = title;
@@ -85,18 +79,6 @@ public class Post {
                 this.district.getCountry().getName() + " " +
                 this.district.getName();
     }
-
-    public int getApplicantNumber() { // 현재 신청한 사람 수
-        return applicants.size();
-    }
-
-    public Long getCurrentNumber() { // 현재 모집된 사람 수
-        return applicants.stream()
-                .distinct()
-                .filter(Applicant::getStatus)
-                .count();
-    }
-
 
     public void addViewCount() { // viewCount 증가
         this.viewCount++;

--- a/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
+++ b/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
@@ -57,8 +57,8 @@ public class PostResponse {
     public record GetPostDto(
             PostDto post
     ) {
-        public GetPostDto(Post post) {
-            this(new PostDto(post));
+        public GetPostDto(Post post, Long currentNumber) {
+            this(new PostDto(post, currentNumber));
         }
 
         public record PostDto(
@@ -77,7 +77,7 @@ public class PostResponse {
                 LocalDateTime editedAt,
                 Boolean isClose
         ) {
-            public PostDto(Post post) {
+            public PostDto(Post post, Long currentNumber) {
                 this(
                         post.getId(),
                         post.getTitle(),
@@ -85,7 +85,7 @@ public class PostResponse {
                         post.getUserName(),
                         post.getProfilePath(),
                         post.getDistrictName(),
-                        post.getCurrentNumber(),
+                        currentNumber,
                         post.getContent(),
                         post.getStartTime(),
                         post.getDueTime(),

--- a/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
+++ b/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
@@ -16,8 +16,15 @@ public class PostResponse {
             CursorRequest nextCursorRequest,
             List<PostDto> posts
     ) {
-        public static GetPostsDto of(CursorRequest nextCursorRequest, List<Post> posts) {
-            return new GetPostsDto(nextCursorRequest, posts.stream().map(PostDto::new).toList());
+        public static GetPostsDto of(CursorRequest nextCursorRequest, List<Post> posts, Map<Long, Long> currentNumberMap) {
+            return new GetPostsDto(
+                    nextCursorRequest,
+                    posts.stream().map(post ->
+                            new PostDto(
+                                    post,
+                                    currentNumberMap.get(post.getId()))
+                    ).toList()
+            );
         }
 
         public record PostDto(
@@ -31,7 +38,7 @@ public class PostResponse {
                 Long currentNumber,
                 Boolean isClose
         ) {
-            public PostDto(Post post) {
+            public PostDto(Post post, Long currentNumber) {
                 this(
                         post.getId(),
                         post.getTitle(),
@@ -40,7 +47,7 @@ public class PostResponse {
                         post.getStartTime(),
                         post.getUserName(),
                         post.getProfilePath(),
-                        post.getCurrentNumber(),
+                        currentNumber,
                         post.getIsClose()
                 );
             }

--- a/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
+++ b/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
@@ -95,8 +95,15 @@ public class PostResponse {
             CursorRequest nextCursorRequest,
             List<PostDto> posts
     ) {
-        public static GetParticipationRecordsDto of(CursorRequest nextCursorRequest, List<Post> posts, Map<Long, List<Score>> scores,
-                                                    Map<Long, List<User>> members, Map<Long, List<UserRate>> rates, Map<Long, Long> applicantIdMap) {
+        public static GetParticipationRecordsDto of(
+                CursorRequest nextCursorRequest,
+                List<Post> posts,
+                Map<Long, List<Score>> scores,
+                Map<Long, List<User>> members,
+                Map<Long, List<UserRate>> rates,
+                Map<Long, Long> applicantIdMap,
+                Map<Long, Long> currentNumberMap
+        ) {
             return new GetParticipationRecordsDto(
                     nextCursorRequest,
                     posts.stream().map(post ->
@@ -105,7 +112,8 @@ public class PostResponse {
                                     scores.get(post.getId()),
                                     members.get(post.getId()),
                                     rates.get(post.getId()),
-                                    applicantIdMap.get(post.getId())
+                                    applicantIdMap.get(post.getId()),
+                                    currentNumberMap.get(post.getId())
                             )).toList()
             );
         }
@@ -122,7 +130,7 @@ public class PostResponse {
                 List<ScoreDto> scores,
                 List<MemberDto> members
         ) {
-            public PostDto(Post post, List<Score> scores, List<User> users, List<UserRate> rates, Long applicantId) {
+            public PostDto(Post post, List<Score> scores, List<User> users, List<UserRate> rates, Long applicantId, Long currentNumber) {
                 this(
                         post.getId(),
                         applicantId,
@@ -130,7 +138,7 @@ public class PostResponse {
                         post.getDueTime(),
                         post.getDistrictName(),
                         post.getStartTime(),
-                        post.getCurrentNumber(),
+                        currentNumber,
                         post.getIsClose(),
                         scores.stream().map(ScoreDto::new).toList(),
                         users.stream().map(user -> new MemberDto(user, rates)).toList()

--- a/src/main/java/com/bungaebowling/server/post/service/PostService.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostService.java
@@ -102,7 +102,10 @@ public class PostService {
 
         Long lastKey = getLastKey(posts);
 
-        return PostResponse.GetPostsDto.of(cursorRequest.next(lastKey, DEFAULT_SIZE), posts);
+        Map<Long, List<Applicant>> applicantMap = getApplicantMap(posts);
+        Map<Long, Long> currentNumberMap = getCurrentNumberMap(posts, applicantMap);
+
+        return PostResponse.GetPostsDto.of(cursorRequest.next(lastKey, DEFAULT_SIZE), posts, currentNumberMap);
     }
 
     private List<Post> findPosts(CursorRequest cursorRequest, Long cityId, Long countryId, Long districtId, Boolean all) {

--- a/src/main/java/com/bungaebowling/server/post/service/PostService.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostService.java
@@ -92,7 +92,9 @@ public class PostService {
 
         post.addViewCount(); // 조회수 1 증가
 
-        return new PostResponse.GetPostDto(post);
+        Long currentNumber = (long) applicantRepository.findAllByPostIdAndStatusTrueOrderByUserIdDesc(post.getId()).size();
+
+        return new PostResponse.GetPostDto(post, currentNumber);
 
     }
 

--- a/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
@@ -18,7 +18,6 @@ import java.time.format.DateTimeFormatter;
 public class PostSpecification {
 
     public static final LocalDateTime START_TIME = LocalDateTime.now().minusMonths(3);
-    public static final LocalDateTime END_TIME = LocalDateTime.now();
 
     public static Specification<Post> conditionEqual(String condition, Long userId) {
         return (root, query, criteriaBuilder) -> {
@@ -69,8 +68,13 @@ public class PostSpecification {
         return (root, query, criteriaBuilder) -> {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
             LocalDateTime startDate = start == null ? START_TIME : LocalDate.parse(start, formatter).atStartOfDay();
-            LocalDateTime endDate = end == null ? END_TIME : LocalDate.parse(end, formatter).plusDays(1).atStartOfDay();
-            return criteriaBuilder.between(root.get("startTime"), startDate, endDate);
+
+            if (end == null) {
+                return criteriaBuilder.greaterThanOrEqualTo(root.get("startTime"), startDate);
+            } else {
+                LocalDateTime endDate = LocalDate.parse(end, formatter).plusDays(1).atStartOfDay();
+                return criteriaBuilder.between(root.get("startTime"), startDate, endDate);
+            }
         };
     }
 

--- a/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
@@ -5,10 +5,7 @@ import com.bungaebowling.server.city.country.Country;
 import com.bungaebowling.server.city.country.district.District;
 import com.bungaebowling.server.post.Post;
 import com.bungaebowling.server.user.User;
-import jakarta.persistence.criteria.Fetch;
-import jakarta.persistence.criteria.Join;
-import jakarta.persistence.criteria.JoinType;
-import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.*;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDate;
@@ -22,17 +19,24 @@ public class PostSpecification {
     public static Specification<Post> conditionEqual(String condition, Long userId) {
         return (root, query, criteriaBuilder) -> {
             Join<Post, User> userJoin = root.join("user", JoinType.LEFT);
-            Join<Post, Applicant> applicantJoin = root.join("applicants", JoinType.LEFT);
-            Join<Applicant, User> applicantUserJoin = applicantJoin.join("user", JoinType.LEFT);
             Fetch<Post, District> districtFetch = root.fetch("district", JoinType.LEFT);
             Fetch<District, Country> countryFetch = districtFetch.fetch("country", JoinType.LEFT);
             countryFetch.fetch("city", JoinType.LEFT);
-            root.fetch("applicants", JoinType.LEFT);
+
+            Subquery<Long> subquery = query.subquery(Long.class);
+            Root<Applicant> applicantRoot = subquery.from(Applicant.class);
+            Join<Applicant, Post> applicantPostJoin = applicantRoot.join("post", JoinType.INNER);
+            subquery.select(applicantPostJoin.get("id"))
+                    .where(
+                            criteriaBuilder.and(
+                                    criteriaBuilder.isTrue(applicantRoot.get("status")),
+                                    criteriaBuilder.equal(applicantRoot.get("user").get("id"), userId)
+                            )
+                    );
 
             Predicate createdPredicate = criteriaBuilder.equal(userJoin.get("id"), userId);
             Predicate participatedPredicate = criteriaBuilder.and(
-                    criteriaBuilder.isTrue(applicantJoin.get("status")),
-                    criteriaBuilder.equal(applicantUserJoin.get("id"), userId),
+                    root.get("id").in(subquery),
                     criteriaBuilder.notEqual(userJoin.get("id"), userId)
             );
 

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -156,4 +156,25 @@ public class ScoreService {
         awsS3Service.deleteFile(score.getResultImageUrl());
         scoreRepository.delete(score);
     }
+
+    public int calculateAverage(List<Score> scores) {
+        return (int) scores.stream()
+                .mapToInt(Score::getScoreNum)
+                .average()
+                .orElse(0.0);
+    }
+
+    public int findMaxScore(List<Score> scores) {
+        return scores.stream()
+                .mapToInt(Score::getScoreNum)
+                .max()
+                .orElse(0);
+    }
+
+    public int findMinScore(List<Score> scores) {
+        return scores.stream()
+                .mapToInt(Score::getScoreNum)
+                .min()
+                .orElse(0);
+    }
 }

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.bungaebowling.server.city.country.district.District;
 import com.bungaebowling.server.city.country.district.repository.DistrictRepository;
 import com.bungaebowling.server.score.Score;
 import com.bungaebowling.server.score.repository.ScoreRepository;
+import com.bungaebowling.server.score.service.ScoreService;
 import com.bungaebowling.server.user.Role;
 import com.bungaebowling.server.user.User;
 import com.bungaebowling.server.user.dto.UserRequest;
@@ -54,6 +55,7 @@ public class UserService {
     private final JavaMailSender javaMailSender;
 
     private final AwsS3Service awsS3Service;
+    private final ScoreService scoreService;
 
     @Value("${bungaebowling.domain}")
     private String domain;
@@ -182,7 +184,7 @@ public class UserService {
         User user = findUserById(userId);
         double rating = getRating(userId);
         List<Score> scores = findScoreByUserId(userId);
-        int average = calculateAverage(scores);
+        int average = scoreService.calculateAverage(scores);
         return new UserResponse.GetUserDto(user, rating, average);
     }
 
@@ -190,7 +192,7 @@ public class UserService {
         User user = findUserById(userId);
         double rating = getRating(userId);
         List<Score> scores = findScoreByUserId(userId);
-        int average = calculateAverage(scores);
+        int average = scoreService.calculateAverage(scores);
         return new UserResponse.GetMyProfileDto(user, rating, average);
     }
 
@@ -226,9 +228,9 @@ public class UserService {
         User user = findUserById(userId);
         List<Score> scores = findScoreByUserId(userId);
         int game = countGames(user);
-        int average = calculateAverage(scores);
-        int maximum = findMaxScore(scores);
-        int minimum = findMinScore(scores);
+        int average = scoreService.calculateAverage(scores);
+        int maximum = scoreService.findMaxScore(scores);
+        int minimum = scoreService.findMinScore(scores);
         return new UserResponse.GetRecordDto(user.getName(), game, average, maximum, minimum);
     }
 
@@ -242,27 +244,6 @@ public class UserService {
 
     private int countGames(User user) {
         return applicantRepository.findAllByUserIdAndPostIsCloseTrueAndStatusTrue(user.getId()).size();
-    }
-
-    private int calculateAverage(List<Score> scores) {
-        return (int) scores.stream()
-                .mapToInt(Score::getScoreNum)
-                .average()
-                .orElse(0.0);
-    }
-
-    private int findMaxScore(List<Score> scores) {
-        return scores.stream()
-                .mapToInt(Score::getScoreNum)
-                .max()
-                .orElse(0);
-    }
-
-    private int findMinScore(List<Score> scores) {
-        return scores.stream()
-                .mapToInt(Score::getScoreNum)
-                .min()
-                .orElse(0);
     }
 
     private double getRating(Long userId) {


### PR DESCRIPTION
## Summary

- 참여 기록 조회 end 없이 조회하면 end 없이 start로만 조회하기
- 평균, 최대 점수, 최소 점수 계산 함수 score service로 이동
- post에서 applicant 양방향 제거
- jpa specification에서 conditionEqual() 수정

## Description

jpa specification는 검색 조건을 조합해서 검색하기 때문에 applicants를 따로 쿼리를 사용해서 가져오더라도 조건에서 post-applicants를 접근하기 어렵다고 생각해서 서브쿼리를 사용했습니다. 더 좋은 방법이 있다면 말씀해 주세요. 
<details>
<summary>실행되는 쿼리</summary>


    select
        p1_0.id,
        p1_0.content,
        p1_0.created_at,
        d1_0.id,
        c1_0.id,
        c2_0.id,
        c2_0.name,
        c1_0.name,
        d1_0.name,
        d1_0.statutory_code,
        p1_0.due_time,
        p1_0.edited_at,
        p1_0.is_close,
        p1_0.start_time,
        p1_0.title,
        p1_0.user_id,
        p1_0.view_count 
    from
        post_tb p1_0 
    left join
        district_tb d1_0 
            on d1_0.id=p1_0.district_id 
    left join
        country_tb c1_0 
            on c1_0.id=d1_0.country_id 
    left join
        city_tb c2_0 
            on c2_0.id=c1_0.city_id 
    where
        (
            p1_0.user_id=? 
            or p1_0.id in ((select
                a1_0.post_id 
            from
                applicant_tb a1_0 
            join
                post_tb p2_0 
                    on p2_0.id=a1_0.post_id 
            where
                a1_0.status 
                and a1_0.user_id=?)) 
            and p1_0.user_id!=?
        ) 
        and 1=1 
        and 1=1 
        and p1_0.start_time>=? 
    order by
        p1_0.id desc offset ? rows fetch first ? rows only


</details>

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #65 
Issue Number: #66 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->