### PR TITLE
점수 등록 API 수정 

### DIFF
--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -51,7 +51,7 @@ public class ScoreService {
             throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "점수를 입력해주세요.");
         }
 
-        if (image == null) { // null 체크 - null인 경우
+        if (image.isEmpty()) { // null 체크 - null인 경우
             saveScoreWithoutImage(userId, post, scoreNum);
         } else { // null 체크 - null이 아닌 경우
             saveScoreWithImage(userId, post, scoreNum, image);

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -51,6 +51,10 @@ public class ScoreService {
             throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "점수를 입력해주세요.");
         }
 
+        if (scoreNum < 0 || scoreNum > 300) {
+            throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "0~300 사이의 숫자만 입력해주세요.");
+        }
+
         if (image.isEmpty()) { // null 체크 - null인 경우
             saveScoreWithoutImage(userId, post, scoreNum);
         } else { // null 체크 - null이 아닌 경우

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -51,11 +51,7 @@ public class ScoreService {
             throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "점수를 입력해주세요.");
         }
 
-        if (image.getSize() > 1) {
-            throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "점수는 1개씩 등록해주세요.");
-        }
-
-        if (image.isEmpty()) { // null 체크 - null인 경우
+        if (image == null) { // null 체크 - null인 경우
             saveScoreWithoutImage(userId, post, scoreNum);
         } else { // null 체크 - null이 아닌 경우
             saveScoreWithImage(userId, post, scoreNum, image);

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -55,7 +55,7 @@ public class ScoreService {
             throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "0~300 사이의 숫자만 입력해주세요.");
         }
 
-        if (image.isEmpty()) { // null 체크 - null인 경우
+        if (image == null) { // null 체크 - null인 경우
             saveScoreWithoutImage(userId, post, scoreNum);
         } else { // null 체크 - null이 아닌 경우
             saveScoreWithImage(userId, post, scoreNum, image);


### PR DESCRIPTION
## Summary
점수 등록 API 관련 버그 수정입니다. 

## Description
### 발견한 버그
- 점수만 등록했을 때
![image (6)](https://github.com/Step3-kakao-tech-campus/Team3_BE/assets/94467302/ec7b7628-f22e-4404-a189-6624196ab1b4)

- 점수와 이미지(1개)를 등록했을 때 
![image (7)](https://github.com/Step3-kakao-tech-campus/Team3_BE/assets/94467302/4a18de6e-5930-4d7a-b447-7121583af272)

### 수정한 코드
기존의 코드에서 getSize() 부분을 제외하였습니다. 
- getSize가 file의 byte수를 체크하는 메소드이기 때문에, 잘못 사용된 코드라는 것을 알게 되어 해당 코드는 삭제했습니다. 
```
if (image.getSize() > 1) {
            throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "점수는 1개씩 등록해주세요.");
}
```
- image null 체크에서는 image를 보내지 않으면, 해당 필드를 포함하지 않는다고 하여, 해당 부분을 참고해서 코드를 수정하였습니다. 
```
if (image == null) { 
... 
}
```

### 추가적으로 수정된 코드 
- 위의 코드들을 수정하면서 점수 숫자 등록에 대한 유효성 검사 코드가 없어, 0~300 사이의 숫자가 아닌 다른 숫자를 넣고 postman에서 test를 해보았을 때, 500 error로 잡는 것을 발견했습니다.
- 따라서, scoreNum이 0~300 사이의 수가 아닐 때, 유효성 검사를 추가하였습니다. 
```
if (scoreNum < 0 || scoreNum > 300) {
            throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "0~300 사이의 숫자만 입력해주세요.");
}
```

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: #69 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->