### PR TITLE
점수 API 개선 

### DIFF
--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
@@ -18,10 +18,12 @@ public enum ErrorCode {
     INVALID_FILE_UPLOAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 파일 업로드 요청입니다."),
     INVALID_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 확장자입니다."),
 
-    SCORE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "점수 등록에 실패했습니다."),
+    SCORE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "점수 등록에 실패하였습니다."),
     SCORE_UPDATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "점수 정보에 대한 수정 권한이 없습니다."),
     SCORE_DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "점수 정보에 대한 삭제 권한이 없습니다."),
     SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 점수입니다."),
+    SCORE_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "점수 수정에 실패하였습니다."),
+    SCORE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 점수이미지 입니다."),
 
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 모집글입니다."),
     POST_NOT_CLOSE(HttpStatus.FORBIDDEN, "모집글이 마감되지 않았습니다."),

--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
@@ -22,7 +22,6 @@ public enum ErrorCode {
     SCORE_UPDATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "점수 정보에 대한 수정 권한이 없습니다."),
     SCORE_DELETE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "점수 정보에 대한 삭제 권한이 없습니다."),
     SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 점수입니다."),
-    SCORE_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "점수 수정에 실패하였습니다."),
     SCORE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 점수이미지 입니다."),
 
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 모집글입니다."),

--- a/src/main/java/com/bungaebowling/server/score/Score.java
+++ b/src/main/java/com/bungaebowling/server/score/Score.java
@@ -54,7 +54,13 @@ public class Score {
         this.accessImageUrl = accessImageUrl;
     }
 
-    public void updateWithFile(Integer scoreNum, String resultImageUrl, LocalDateTime updatedAt, String accessImageUrl) {
+    public void updateWithFile(String resultImageUrl, LocalDateTime updatedAt, String accessImageUrl) {
+        this.resultImageUrl = resultImageUrl;
+        this.createdAt = updatedAt;
+        this.accessImageUrl = accessImageUrl;
+    }
+
+    public void updateWithFileAndNum(Integer scoreNum, String resultImageUrl, LocalDateTime updatedAt, String accessImageUrl) {
         this.scoreNum = scoreNum;
         this.resultImageUrl = resultImageUrl;
         this.createdAt = updatedAt;

--- a/src/main/java/com/bungaebowling/server/score/Score.java
+++ b/src/main/java/com/bungaebowling/server/score/Score.java
@@ -54,21 +54,13 @@ public class Score {
         this.accessImageUrl = accessImageUrl;
     }
 
-    public void updateWithFile(String resultImageUrl, LocalDateTime updatedAt, String accessImageUrl) {
+    public void updateWithFile(String resultImageUrl, String accessImageUrl) {
         this.resultImageUrl = resultImageUrl;
-        this.createdAt = updatedAt;
+        this.createdAt = LocalDateTime.now();
         this.accessImageUrl = accessImageUrl;
     }
 
-    public void updateWithFileAndNum(Integer scoreNum, String resultImageUrl, LocalDateTime updatedAt, String accessImageUrl) {
+    public void updateScoreNum(Integer scoreNum) {
         this.scoreNum = scoreNum;
-        this.resultImageUrl = resultImageUrl;
-        this.createdAt = updatedAt;
-        this.accessImageUrl = accessImageUrl;
-    }
-
-    public void updateWithoutFile(Integer scoreNum, LocalDateTime updatedAt) {
-        this.scoreNum = scoreNum;
-        this.createdAt = updatedAt;
     }
 }

--- a/src/main/java/com/bungaebowling/server/score/controller/ScoreController.java
+++ b/src/main/java/com/bungaebowling/server/score/controller/ScoreController.java
@@ -50,6 +50,17 @@ public class ScoreController {
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 
+    @DeleteMapping("{postId}/scores/{scoreId}/image")
+    public ResponseEntity<?> deleteScoreImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long postId,
+            @PathVariable Long scoreId
+    ) {
+        scoreService.deleteImage(userDetails.getId(), postId, scoreId);
+
+        return ResponseEntity.ok(ApiUtils.success());
+    }
+
     @DeleteMapping("{postId}/scores/{scoreId}")
     public ResponseEntity<?> deleteScore(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/bungaebowling/server/score/controller/ScoreController.java
+++ b/src/main/java/com/bungaebowling/server/score/controller/ScoreController.java
@@ -42,7 +42,7 @@ public class ScoreController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId,
             @PathVariable Long scoreId,
-            @RequestParam(name = "score") Integer scoreNum,
+            @RequestParam(name = "score", required = false) Integer scoreNum,
             @RequestParam(name = "image", required = false) MultipartFile image
     ) {
         scoreService.update(userDetails.getId(), postId, scoreId, scoreNum, image);

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -131,9 +131,7 @@ public class ScoreService {
     }
 
     private void updateScoreWithFile(Integer scoreNum, MultipartFile image, Long postId, User user, Score score, LocalDateTime updateTime) {
-        if (score.getResultImageUrl() != null) { // 기존에 파일이 있다면
-            awsS3Service.deleteFile(score.getResultImageUrl()); // 기존에 있던 파일 지워주기
-        }
+        deleteImageIfFileExist(score);
 
         if (image.isEmpty()) {
             score.updateWithFile(null, updateTime, null);
@@ -168,8 +166,14 @@ public class ScoreService {
     }
 
     private void deleteScore(Score score) {
-        awsS3Service.deleteFile(score.getResultImageUrl());
+        deleteImageIfFileExist(score);
         scoreRepository.delete(score);
+    }
+
+    private void deleteImageIfFileExist(Score score) { // 기존에 파일 있으면 지워주기
+        if (score.getResultImageUrl() != null) {
+            awsS3Service.deleteFile(score.getResultImageUrl());
+        }
     }
 
     public int calculateAverage(List<Score> scores) {

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -117,25 +117,29 @@ public class ScoreService {
 
         if (image == null) { // null 체크 - null인 경우
             validateScoreNum(scoreNum);
-            score.updateWithoutFile(scoreNum, updateTime);
+            score.updateWithoutFile(scoreNum, updateTime); // 점수 수정 - scoreNum만 변경
         } else {
             updateScoreWithFile(scoreNum, image, postId, user, score, updateTime);
         }
     }
 
     private void updateScoreWithFile(Integer scoreNum, MultipartFile image, Long postId, User user, Score score, LocalDateTime updateTime) {
-        deleteImageIfFileExist(score);
+        if (image.isEmpty()) { // 점수 수정 - 이미지만 삭제
+            if (score.getResultImageUrl() != null) {
+                throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "삭제할 이미지가 존재하지 않습니다.");
+            }
 
-        if (image.isEmpty()) {
             score.updateWithFile(null, updateTime, null);
-        } else {
+        } else { // 점수 수정 - 이미지 변경
+            deleteImageIfFileExist(score);
+
             String imageUrl = awsS3Service.uploadScoreFile(user.getId(), postId, "score", updateTime, image);
             String accessImageUrl = awsS3Service.getImageAccessUrl(imageUrl);
 
-            if (scoreNum == null) {
+            if (scoreNum == null) { // scoreNum은 변경 안 할 경우
                 score.updateWithFile(imageUrl, updateTime, accessImageUrl);
             } else {
-                validateScoreNum(scoreNum);
+                validateScoreNum(scoreNum); // scoreNum도 변경할 경우
                 score.updateWithFileAndNum(scoreNum, imageUrl, updateTime, accessImageUrl);
             }
         }

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -124,24 +124,16 @@ public class ScoreService {
     }
 
     private void updateScoreWithFile(Integer scoreNum, MultipartFile image, Long postId, User user, Score score, LocalDateTime updateTime) {
-        if (image.isEmpty()) { // 점수 수정 - 이미지만 삭제
-            if (score.getResultImageUrl() == null) {
-                throw new CustomException(ErrorCode.SCORE_IMAGE_NOT_FOUND, "삭제할 이미지가 존재하지 않습니다.");
-            }
+        deleteImageIfFileExist(score);
 
-            score.updateWithFile(null, updateTime, null);
-        } else { // 점수 수정 - 이미지 변경
-            deleteImageIfFileExist(score);
+        String imageUrl = awsS3Service.uploadScoreFile(user.getId(), postId, "score", updateTime, image);
+        String accessImageUrl = awsS3Service.getImageAccessUrl(imageUrl);
 
-            String imageUrl = awsS3Service.uploadScoreFile(user.getId(), postId, "score", updateTime, image);
-            String accessImageUrl = awsS3Service.getImageAccessUrl(imageUrl);
-
-            if (scoreNum == null) { // scoreNum은 변경 안 할 경우
-                score.updateWithFile(imageUrl, updateTime, accessImageUrl);
-            } else {
-                validateScoreNum(scoreNum); // scoreNum도 변경할 경우
-                score.updateWithFileAndNum(scoreNum, imageUrl, updateTime, accessImageUrl);
-            }
+        if (scoreNum == null) { // scoreNum은 변경 안 할 경우
+            score.updateWithFile(imageUrl, updateTime, accessImageUrl);
+        } else {
+            validateScoreNum(scoreNum); // scoreNum도 변경할 경우
+            score.updateWithFileAndNum(scoreNum, imageUrl, updateTime, accessImageUrl);
         }
     }
 

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -125,7 +125,7 @@ public class ScoreService {
 
     private void updateScoreWithFile(Integer scoreNum, MultipartFile image, Long postId, User user, Score score, LocalDateTime updateTime) {
         if (image.isEmpty()) { // 점수 수정 - 이미지만 삭제
-            if (score.getResultImageUrl() != null) {
+            if (score.getResultImageUrl() == null) {
                 throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "삭제할 이미지가 존재하지 않습니다.");
             }
 

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -114,15 +114,12 @@ public class ScoreService {
             throw new CustomException(ErrorCode.SCORE_UPDATE_PERMISSION_DENIED);
         }
 
-        Integer scoreNumCheck = Optional.ofNullable(scoreNum)
-                .orElseThrow(() -> new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "점수를 입력해주세요."));
-
         User user = findUserById(userId);
         Score score = findScoreById(scoreId);
         LocalDateTime updateTime = LocalDateTime.now();
 
         if (image == null) { // null 체크 - null인 경우
-            score.updateWithoutFile(scoreNumCheck, updateTime);
+            score.updateWithoutFile(scoreNum, updateTime);
         } else { // null 체크 - null이 아닌 경우
             if (score.getResultImageUrl() != null) { // 기존에 파일이 있다면
                 awsS3Service.deleteFile(score.getResultImageUrl()); // 기존에 있던 파일 지워주기
@@ -130,7 +127,7 @@ public class ScoreService {
             String imageurl = awsS3Service.uploadScoreFile(user.getId(), postId, "score", updateTime, image);
             String accessImageUrl = awsS3Service.getImageAccessUrl(imageurl);
 
-            score.updateWithFile(scoreNumCheck, imageurl, updateTime, accessImageUrl);
+            score.updateWithFile(scoreNum, imageurl, updateTime, accessImageUrl);
         }
     }
 

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -110,9 +110,7 @@ public class ScoreService {
     public void update(Long userId, Long postId, Long scoreId, Integer scoreNum, MultipartFile image) {
         Post post = findPostById(postId);
 
-        if (!post.isMine(userId)) {
-            throw new CustomException(ErrorCode.SCORE_UPDATE_PERMISSION_DENIED);
-        }
+        checkPostPermission(userId, post);
 
         User user = findUserById(userId);
         Score score = findScoreById(scoreId);
@@ -156,13 +154,17 @@ public class ScoreService {
     public void delete(Long userId, Long postId, Long scoreId) {
         Post post = findPostById(postId);
 
-        if (!post.isMine(userId)) {
-            throw new CustomException(ErrorCode.SCORE_DELETE_PERMISSION_DENIED);
-        }
+        checkPostPermission(userId, post);
 
         Score score = findScoreById(scoreId);
 
         deleteScore(score);
+    }
+
+    private void checkPostPermission(Long userId, Post post){
+        if (!post.isMine(userId)) {
+            throw new CustomException(ErrorCode.SCORE_DELETE_PERMISSION_DENIED);
+        }
     }
 
     private void deleteScore(Score score) {

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -124,10 +124,15 @@ public class ScoreService {
             if (score.getResultImageUrl() != null) { // 기존에 파일이 있다면
                 awsS3Service.deleteFile(score.getResultImageUrl()); // 기존에 있던 파일 지워주기
             }
+
             String imageurl = awsS3Service.uploadScoreFile(user.getId(), postId, "score", updateTime, image);
             String accessImageUrl = awsS3Service.getImageAccessUrl(imageurl);
 
-            score.updateWithFile(scoreNum, imageurl, updateTime, accessImageUrl);
+            if (scoreNum == null) {
+                score.updateWithFile(imageurl, updateTime, accessImageUrl);
+            } else {
+                score.updateWithFileAndNum(scoreNum, imageurl, updateTime, accessImageUrl);
+            }
         }
     }
 

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -126,7 +126,7 @@ public class ScoreService {
     private void updateScoreWithFile(Integer scoreNum, MultipartFile image, Long postId, User user, Score score, LocalDateTime updateTime) {
         if (image.isEmpty()) { // 점수 수정 - 이미지만 삭제
             if (score.getResultImageUrl() == null) {
-                throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "삭제할 이미지가 존재하지 않습니다.");
+                throw new CustomException(ErrorCode.SCORE_IMAGE_NOT_FOUND, "삭제할 이미지가 존재하지 않습니다.");
             }
 
             score.updateWithFile(null, updateTime, null);

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -47,13 +47,7 @@ public class ScoreService {
             throw new CustomException(ErrorCode.POST_NOT_CLOSE, "아직 점수를 등록할 수 없습니다.");
         }
 
-        if (scoreNum == null) {
-            throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "점수를 입력해주세요.");
-        }
-
-        if (scoreNum < 0 || scoreNum > 300) {
-            throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "0~300 사이의 숫자만 입력해주세요.");
-        }
+        validateScoreNum(scoreNum);
 
         if (image == null) { // null 체크 - null인 경우
             saveScoreWithoutImage(userId, post, scoreNum);
@@ -122,6 +116,7 @@ public class ScoreService {
         LocalDateTime updateTime = LocalDateTime.now();
 
         if (image == null) { // null 체크 - null인 경우
+            validateScoreNum(scoreNum);
             score.updateWithoutFile(scoreNum, updateTime);
         } else {
             updateScoreWithFile(scoreNum, image, postId, user, score, updateTime);
@@ -140,6 +135,7 @@ public class ScoreService {
             if (scoreNum == null) {
                 score.updateWithFile(imageUrl, updateTime, accessImageUrl);
             } else {
+                validateScoreNum(scoreNum);
                 score.updateWithFileAndNum(scoreNum, imageUrl, updateTime, accessImageUrl);
             }
         }
@@ -148,6 +144,16 @@ public class ScoreService {
     private Score findScoreById(Long scoreId) {
         return scoreRepository.findById(scoreId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SCORE_NOT_FOUND));
+    }
+
+    private void validateScoreNum(Integer scoreNum) {
+        if (scoreNum == null) {
+            throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "점수를 입력해주세요.");
+        }
+
+        if (scoreNum < 0 || scoreNum > 300) {
+            throw new CustomException(ErrorCode.SCORE_UPLOAD_FAILED, "0~300 사이의 숫자만 입력해주세요.");
+        }
     }
 
     @Transactional

--- a/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
+++ b/src/main/java/com/bungaebowling/server/score/service/ScoreService.java
@@ -121,7 +121,7 @@ public class ScoreService {
         Score score = findScoreById(scoreId);
         LocalDateTime updateTime = LocalDateTime.now();
 
-        if (image.isEmpty()) { // null 체크 - null인 경우
+        if (image == null) { // null 체크 - null인 경우
             score.updateWithoutFile(scoreNumCheck, updateTime);
         } else { // null 체크 - null이 아닌 경우
             if (score.getResultImageUrl() != null) { // 기존에 파일이 있다면


### PR DESCRIPTION
## Summary

점수 API를 개선하였습니다. 

- 점수 수정 API 개선 
- 점수 삭제 API 개선 
- 점수 이미지 삭제 API 추가 

## Description

### 점수 수정 API 개선 
점수 수정에 관해서 고려해야 할 사항은 총 7가지입니다. 
- case 1 : 점수(숫자)만 등록했을 때, 점수(숫자)만 수정 가능한지 
- case 2 : 점수(숫자)만 등록했을 때, 점수(숫자)수정 및 이미지 등록 가능한지 
- case 3 : 점수(숫자)만 등록했을 때, 수정 시 이미지만 등록 가능한지
- case 4 : 점수(숫자), 이미지 등록했을 때, 점수(숫자)만 수정 가능한지 
- case 5 : 점수(숫자), 이미지 등록했을 때, 이미지만 수정 가능한지 - **이미지 변경** 
- case 6 : 점수(숫자), 이미지 등록했을 때, 점수(숫자)수정 및 이미지 수정 가능한지 
- case 7 : 점수(숫자), 이미지 등록했을 때, 이미지 삭제할 수 있는지 - **이미지 삭제** 

위의 7가지 상황을 고려해서 점수 수정 API 코드를 개선해주었습니다. 

점수 이미지 삭제와 관련해서는 제가 직접 프론트 코드로 테스트 해본 결과 image를 빈 파일로 전달해주더라도 image 필드를 전달해주지 않는 것으로 확인이 되는 것 같아 점수 이미지 삭제 API를 따로 구현하는 것으로 변경하였습니다. 

### 점수 삭제 API 개선 
점수 삭제와 관련해 점수(숫자)만 등록했을 경우, 점수가 삭제되지 않는 버그를 발견해 점수 이미지 여부에 관계없이 점수를 삭제해주는 상황을 반영하여 코드 수정했습니다. 

### 점수 이미지 삭제 API 추가 
점수 이미지 삭제 API 추가하였습니다. 
```
DELETE /api/posts/{post_id}/scores/{score_id}/image
```

따라서, 점수 이미지 삭제 API 명세도 추가해주었습니다. 
[점수 이미지 삭제 API](https://www.notion.so/aef3994e9e794d10a82a440b87d83d64?pvs=4)

#### 추가 정보 
customException에 ErrorCode에 점수 이미지 삭제와 관련해서 404 NOT FOUND error를 추가하였습니다.

## Related Issue

Issue Number: #82 , #83 
