### PR TITLE
유저 컨트롤러 문서화 완료

### DIFF
--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -33,6 +33,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -111,6 +112,9 @@ public class UserService {
 
     public UserResponse.TokensDto reIssueTokens(String refreshToken) {
         var decodedRefreshToken = JwtProvider.verify(refreshToken, JwtProvider.TYPE_REFRESH);
+
+        if (!Objects.equals(redisTemplate.opsForValue().get(decodedRefreshToken.getSubject()), refreshToken))
+            throw new CustomException(ErrorCode.INVALID_TOKEN, "유효하지 않은 refresh 토큰입니다.");
 
         var user = userRepository.findById(Long.valueOf(decodedRefreshToken.getSubject())).orElseThrow(() ->
                 new CustomException(ErrorCode.UNKNOWN_SERVER_ERROR, "재발급 과정에서 오류가 발생했습니다."));

--- a/src/test/java/com/bungaebowling/server/ControllerTestConfig.java
+++ b/src/test/java/com/bungaebowling/server/ControllerTestConfig.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -36,6 +37,7 @@ public abstract class ControllerTestConfig {
     void setUp(final RestDocumentationContextProvider restDocumentationContextProvider) {
         mvc = MockMvcBuilders.webAppContextSetup((context))
                 .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentationContextProvider))
+                .apply(SecurityMockMvcConfigurers.springSecurity())
                 .addFilters(new CharacterEncodingFilter("UTF-8", true))
                 .alwaysDo(MockMvcResultHandlers.print())
                 .build();

--- a/src/test/java/com/bungaebowling/server/GeneralApiResponseSchema.java
+++ b/src/test/java/com/bungaebowling/server/GeneralApiResponseSchema.java
@@ -20,6 +20,16 @@ public enum GeneralApiResponseSchema {
                     fieldWithPath("response").type(SimpleType.STRING).description("에러 코드"),
                     fieldWithPath("errorMessage").type(SimpleType.STRING).description("에러 메시지")
             )
+    ),
+    NEXT_CURSOR("커서 페이징 응답 DTO",
+            new FieldDescriptors(
+                    fieldWithPath("status").type(SimpleType.NUMBER).description("응답 상태 정보"),
+                    fieldWithPath("response").type(SimpleType.STRING).optional().description("응답 body"),
+                    fieldWithPath("errorMessage").type(SimpleType.STRING).optional().description("에러 메시지"),
+                    fieldWithPath("response.nextCursorRequest").description("다음 요청 cursor 정보(받은 값 그대로 다음 요청에 사용할 것)"),
+                    fieldWithPath("response.nextCursorRequest.key").description("다음 요청 cursor의 key"),
+                    fieldWithPath("response.nextCursorRequest.size").description("다음 요청 cursor의 size")
+            )
     );
 
     private final String name;

--- a/src/test/java/com/bungaebowling/server/city/controller/CityControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/city/controller/CityControllerTest.java
@@ -60,7 +60,7 @@ class CityControllerTest extends ControllerTestConfig {
                 jsonPath("$.response.cities[0].name").exists()
         ).andDo(
                 MockMvcRestDocumentationWrapper.document(
-                        "getCities",
+                        "[city] getCities",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         resource(
@@ -105,7 +105,7 @@ class CityControllerTest extends ControllerTestConfig {
                 jsonPath("$.response.countries[0].name").exists()
         ).andDo(
                 MockMvcRestDocumentationWrapper.document(
-                        "getCountries",
+                        "[city] getCountries",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         resource(
@@ -155,7 +155,7 @@ class CityControllerTest extends ControllerTestConfig {
                 jsonPath("$.response.districts[0].name").exists()
         ).andDo(
                 MockMvcRestDocumentationWrapper.document(
-                        "getDistricts",
+                        "[city] getDistricts",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         resource(
@@ -208,7 +208,7 @@ class CityControllerTest extends ControllerTestConfig {
                 jsonPath("$.response.name").exists()
         ).andDo(
                 MockMvcRestDocumentationWrapper.document(
-                        "getDistrictInfo",
+                        "[city] getDistrictInfo",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         resource(

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -42,7 +42,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -913,8 +912,8 @@ class UserControllerTest extends ControllerTestConfig {
         Long userId = 1L;
         // when
         ResultActions resultActions = mvc.perform(
-                MockMvcRequestBuilders
-                        .get("/api/users/" + userId + "/records")
+                RestDocumentationRequestBuilders
+                        .get("/api/users/{userId}/records", userId)
         );
 
         // then
@@ -930,6 +929,32 @@ class UserControllerTest extends ControllerTestConfig {
                 jsonPath("$.response.average").isNumber(),
                 jsonPath("$.response.maximum").isNumber(),
                 jsonPath("$.response.minimum").isNumber()
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[user] getUserRecords",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("사용자 기록(경기수, 평균점수) 조회")
+                                        .description("""
+                                                사용자의 경기 기록을 조회합니다.
+                                                 """)
+                                        .tag(ApiTag.USER.getTagName())
+                                        .pathParameters(parameterWithName("userId").type(SimpleType.NUMBER).description("사용자 id"))
+                                        .responseSchema(Schema.schema("사용자 기록(경기수, 평균점수) 조회 응답 DTO"))
+                                        .responseFields(
+                                                GeneralApiResponseSchema.SUCCESS.getResponseDescriptor().and(
+                                                        fieldWithPath("response.name").description("사용자의 이름(닉네임)"),
+                                                        fieldWithPath("response.game").description("참여 게임 수"),
+                                                        fieldWithPath("response.average").description("볼링 게임 평균 점수(참여 기록 없을 시 0)"),
+                                                        fieldWithPath("response.maximum").description("볼링 게임 최고 점수(참여 기록 없을 시 0)"),
+                                                        fieldWithPath("response.minimum").description("볼링 게임 최저 점수(참여 기록 없을 시 0)")
+                                                )
+                                        )
+                                        .build()
+                        )
+                )
         );
     }
 }

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -49,8 +49,7 @@ import org.springframework.web.context.WebApplicationContext;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -511,7 +510,7 @@ class UserControllerTest extends ControllerTestConfig {
 
         // when
         ResultActions resultActions = mvc.perform(
-                MockMvcRequestBuilders
+                RestDocumentationRequestBuilders
                         .get("/api/users")
         );
 
@@ -528,6 +527,30 @@ class UserControllerTest extends ControllerTestConfig {
                 jsonPath("$.response.users[0].name").exists(),
                 jsonPath("$.response.users[0].rating").isNumber(),
                 jsonPath("$.response.users[0].profileImage").hasJsonPath()
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[user] getUsers",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("사용자 목록 조회")
+                                        .description("""
+                                                검색어를 포함하는 사용자를 모두 조회합니다.
+                                                """)
+                                        .tag(ApiTag.USER.getTagName())
+                                        .responseSchema(Schema.schema("사용자 목록 조회 응답 DTO"))
+                                        .responseFields(
+                                                GeneralApiResponseSchema.NEXT_CURSOR.getResponseDescriptor().and(
+                                                        fieldWithPath("response.users[].id").description("사용자의 ID(PK)"),
+                                                        fieldWithPath("response.users[].name").description("이름"),
+                                                        fieldWithPath("response.users[].rating").description("사용자의 별점"),
+                                                        fieldWithPath("response.users[].profileImage").description("사용자의 프로필 이미지 링크")
+                                                )
+                                        )
+                                        .build()
+                        )
+                )
         );
     }
 
@@ -535,10 +558,10 @@ class UserControllerTest extends ControllerTestConfig {
     @DisplayName("사용자 목록 조회 테스트 - name 검색")
     void getUsersWithName() throws Exception {
         // given
-        String searchName = "볼링";
+        String searchName = "이볼";
         // when
         ResultActions resultActions = mvc.perform(
-                MockMvcRequestBuilders
+                RestDocumentationRequestBuilders
                         .get("/api/users")
                         .param("name", searchName)
         );
@@ -550,6 +573,27 @@ class UserControllerTest extends ControllerTestConfig {
 
         resultActions.andExpect(
                 jsonPath("$.response.users[*].name", everyItem(containsString(searchName)))
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[user] getUsersWithName",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(ApiTag.USER.getTagName())
+                                        .queryParameters(parameterWithName("name").optional().description("검색할 유저의 별명"))
+                                        .responseSchema(Schema.schema("사용자 목록 조회 응답 DTO"))
+                                        .responseFields(
+                                                GeneralApiResponseSchema.NEXT_CURSOR.getResponseDescriptor().and(
+                                                        fieldWithPath("response.users[].id").description("사용자의 ID(PK)"),
+                                                        fieldWithPath("response.users[].name").description("이름"),
+                                                        fieldWithPath("response.users[].rating").description("사용자의 별점"),
+                                                        fieldWithPath("response.users[].profileImage").description("사용자의 프로필 이미지 링크")
+                                                )
+                                        )
+                                        .build()
+                        )
+                )
         );
     }
 

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -468,7 +468,7 @@ class UserControllerTest extends ControllerTestConfig {
 
         // when
         ResultActions resultActions = mvc.perform(
-                MockMvcRequestBuilders
+                RestDocumentationRequestBuilders
                         .post("/api/email-confirm")
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -482,6 +482,25 @@ class UserControllerTest extends ControllerTestConfig {
         resultActions.andExpectAll(
                 status().isOk(),
                 jsonPath("$.status").value(200)
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[user] confirmEmail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("메일 인증")
+                                        .description("""
+                                                이메일로 받은 토큰을 사용하여 메일 인증을 수행합니다. 유저의 권한이 상승됩니다.
+                                                """)
+                                        .tag(ApiTag.AUTHORIZATION.getTagName())
+                                        .requestSchema(Schema.schema("메일 인증 요청 DTO"))
+                                        .requestFields(fieldWithPath("token").type(SimpleType.STRING).description("이메일로 제공 받은 인증 토큰"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.SUCCESS.getName()))
+                                        .responseFields(GeneralApiResponseSchema.SUCCESS.getResponseDescriptor())
+                                        .build()
+                        )
+                )
         );
     }
 

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -110,7 +110,7 @@ class UserControllerTest extends ControllerTestConfig {
                 jsonPath("$.status").value(200)
         ).andDo(
                 MockMvcRestDocumentationWrapper.document(
-                        "join",
+                        "[user] join",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         resource(
@@ -175,7 +175,7 @@ class UserControllerTest extends ControllerTestConfig {
                 jsonPath("$.status").value(200)
         ).andDo(
                 MockMvcRestDocumentationWrapper.document(
-                        "login",
+                        "[user] login",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         resource(
@@ -256,7 +256,7 @@ class UserControllerTest extends ControllerTestConfig {
                 jsonPath("$.response").value(ErrorCode.LOGIN_FAILED.toString())
         ).andDo(
                 MockMvcRestDocumentationWrapper.document(
-                        "loginFail",
+                        "[user] login - fail",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         resource(

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -545,7 +545,7 @@ class UserControllerTest extends ControllerTestConfig {
                                                         fieldWithPath("response.users[].id").description("사용자의 ID(PK)"),
                                                         fieldWithPath("response.users[].name").description("이름"),
                                                         fieldWithPath("response.users[].rating").description("사용자의 별점"),
-                                                        fieldWithPath("response.users[].profileImage").description("사용자의 프로필 이미지 링크")
+                                                        fieldWithPath("response.users[].profileImage").type(SimpleType.STRING).optional().description("사용자의 프로필 이미지 링크 | 이미지 설정 안한 경우 null")
                                                 )
                                         )
                                         .build()
@@ -581,14 +581,14 @@ class UserControllerTest extends ControllerTestConfig {
                         resource(
                                 ResourceSnippetParameters.builder()
                                         .tag(ApiTag.USER.getTagName())
-                                        .queryParameters(parameterWithName("name").optional().description("검색할 유저의 별명"))
+                                        .queryParameters(parameterWithName("name").optional().description("검색할 유저의 이름(닉네임)"))
                                         .responseSchema(Schema.schema("사용자 목록 조회 응답 DTO"))
                                         .responseFields(
                                                 GeneralApiResponseSchema.NEXT_CURSOR.getResponseDescriptor().and(
                                                         fieldWithPath("response.users[].id").description("사용자의 ID(PK)"),
-                                                        fieldWithPath("response.users[].name").description("이름"),
+                                                        fieldWithPath("response.users[].name").description("이름(닉네임)"),
                                                         fieldWithPath("response.users[].rating").description("사용자의 별점"),
-                                                        fieldWithPath("response.users[].profileImage").description("사용자의 프로필 이미지 링크")
+                                                        fieldWithPath("response.users[].profileImage").type(SimpleType.STRING).optional().description("사용자의 프로필 이미지 링크 | 이미지 설정 안한 경우 null")
                                                 )
                                         )
                                         .build()
@@ -604,8 +604,8 @@ class UserControllerTest extends ControllerTestConfig {
         long userId = 1L;
         // when
         ResultActions resultActions = mvc.perform(
-                MockMvcRequestBuilders
-                        .get("/api/users/" + userId)
+                RestDocumentationRequestBuilders
+                        .get("/api/users/{userId}", userId)
         );
 
         // then
@@ -621,6 +621,34 @@ class UserControllerTest extends ControllerTestConfig {
                 jsonPath("$.response.rating").isNumber(),
                 jsonPath("$.response.address").exists(),
                 jsonPath("$.response.profileImage").hasJsonPath()
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[user] getUser",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("사용자 상세 조회")
+                                        .description("""
+                                                특정 사용자의 상세 정보를 확인합니다.
+                                                 """)
+                                        .tag(ApiTag.USER.getTagName())
+                                        .pathParameters(
+                                                parameterWithName("userId").type(SimpleType.NUMBER).description("사용자 id")
+                                        )
+                                        .responseSchema(Schema.schema("사용자 상세 조회 응답 DTO"))
+                                        .responseFields(
+                                                GeneralApiResponseSchema.SUCCESS.getResponseDescriptor().and(
+                                                        fieldWithPath("response.name").description("사용자의 이름(닉네임)"),
+                                                        fieldWithPath("response.averageScore").description("볼링 게임 평균 점수"),
+                                                        fieldWithPath("response.rating").description("별점(매너 점수) | 별점 받은 적 없는 경우 0"),
+                                                        fieldWithPath("response.address").description("사용자의 별점"),
+                                                        fieldWithPath("response.profileImage").type(SimpleType.STRING).optional().description("사용자의 프로필 이미지 링크 | 이미지 설정 안한 경우 null")
+                                                )
+                                        )
+                                        .build()
+                        )
+                )
         );
     }
 


### PR DESCRIPTION
## Summary

유저 컨트롤러에 대한 문서화를 완료하였습니다.

문서화는 복사 붙여넣기가 많다보니까 PR 분량 조절이 너무 어려운거 같습니다... swagger로 결과물 확인하시는게 나을거 같습니다.

https://server.jagaldol.dev:8080/api/docs/swagger 제 개인 서버에 먼저 올려두었습니다. 여기서 현재까지의 api 문서화를 확인하실 수 있습니다.

## Description

우여곡절이 많았는데, 일단 multipart/form-data의 경우 parameter 문서화가 안되서 직접 적었습니다.

- 관련 이슈: [Support for multipart parameter](https://github.com/ePages-de/restdocs-api-spec/issues/205)

그렇다고 하더라도 어떻게 전부 문서화 해놨고 쓸만한 거 같습니다.

저번에 이메일 보내는 테스트 mocking을 실패해서 주석 처리해놨었는데, 이것도 어떻게 해결하여 같이 문서화 하였습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: #63
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->