### PR TITLE
CORS 정보 environment variable로 주입

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 TOKEN_SECRET="bungaebowling"
 DOMAIN="http://localhost:3000"
+API_SERVER_URL="http://localhost:8080"
 GMAIL_USERNAME="input_your_gmail"
 GMAIL_APPLICATION_PASSWORD="input_your_gmail_application_password"
 AWS_ACCESS_KEY="input_your_aws_access_key"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
 	ext {
+		apiServerUrl = System.getenv("API_SERVER_URL")
 		new File('.env').getText('UTF-8').splitEachLine(/=/) {
 			if (it[0] == "API_SERVER_URL") {
 				apiServerUrl = it[1].replaceAll('"', '')

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+	ext {
+		new File('.env').getText('UTF-8').splitEachLine(/=/) {
+			if (it[0] == "API_SERVER_URL") {
+				apiServerUrl = it[1].replaceAll('"', '')
+			}
+		}
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.3'
@@ -75,7 +85,7 @@ bootJar {
 
 openapi3 {
 	servers = [
-			{ url = "https://bungae.jagaldol.dev" },
+			{ url = apiServerUrl },
 			{ url = "http://localhost:8080" }
 	]
 	title = "번개볼링 API Documents"

--- a/k8s/backend.yaml
+++ b/k8s/backend.yaml
@@ -62,6 +62,11 @@ spec:
                 secretKeyRef:
                   name: secrets
                   key: GOOGLE_MAP_API_KEY
+            - name: API_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: secrets
+                  key: API_SERVER_URL
           ports:
             - containerPort: 8080
           resources:

--- a/k8s/create-k8s-secret.sh
+++ b/k8s/create-k8s-secret.sh
@@ -18,7 +18,8 @@ kubectl create secret generic $SECRET_NAME \
   --from-literal=MYSQL_USERNAME="$MYSQL_USERNAME" \
   --from-literal=MYSQL_PASSWORD="$MYSQL_PASSWORD" \
   --from-literal=DOMAIN="$DOMAIN" \
-  --from-literal=GOOGLE_MAP_API_KEY="$GOOGLE_MAP_API_KEY"
+  --from-literal=GOOGLE_MAP_API_KEY="$GOOGLE_MAP_API_KEY" \
+  --from-literal=API_SERVER_URL="$API_SERVER_URL"
 
 
 echo "Kubernetes secret $SECRET_NAME has been created or updated with the environment variables."

--- a/src/main/java/com/bungaebowling/server/_core/config/Configs.java
+++ b/src/main/java/com/bungaebowling/server/_core/config/Configs.java
@@ -10,15 +10,7 @@ import java.util.List;
 public class Configs {
 
     @Getter
-    private static String apiServerUrl;
-
-    @Getter
     private static String domain;
-
-    @Value("${bungaebowling.api_server_url}")
-    private void setApiServerUrl(String value) {
-        apiServerUrl = value;
-    }
 
     @Value("${bungaebowling.domain}")
     private void setDomain(String value) {
@@ -33,7 +25,6 @@ public class Configs {
 
     public static List<String> getFullCORS() {
         List<String> fullCORS = new ArrayList<>(CORS);
-        fullCORS.add(apiServerUrl);
         fullCORS.add(domain);
         return fullCORS;
     }

--- a/src/main/java/com/bungaebowling/server/_core/config/Configs.java
+++ b/src/main/java/com/bungaebowling/server/_core/config/Configs.java
@@ -1,11 +1,40 @@
 package com.bungaebowling.server._core.config;
 
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 public class Configs {
+
+    @Getter
+    private static String apiServerUrl;
+
+    @Getter
+    private static String domain;
+
+    @Value("${bungaebowling.api_server_url}")
+    private void setApiServerUrl(String value) {
+        apiServerUrl = value;
+    }
+
+    @Value("${bungaebowling.domain}")
+    private void setDomain(String value) {
+        domain = value;
+    }
+
+
     public final static List<String> CORS = Collections.unmodifiableList(
             List.of("http://localhost:3000", // 리액트 개발용 3000포트
                     "http://127.0.0.1:3000")
     );
+
+    public static List<String> getFullCORS() {
+        List<String> fullCORS = new ArrayList<>(CORS);
+        fullCORS.add(apiServerUrl);
+        fullCORS.add(domain);
+        return fullCORS;
+    }
 }

--- a/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/SecurityConfig.java
@@ -98,7 +98,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*"); // GET, POST, PUT, DELETE (Javascript 요청 허용)
-        configuration.setAllowedOrigins(Configs.CORS);
+        configuration.setAllowedOrigins(Configs.getFullCORS());
         configuration.setAllowCredentials(true); // 클라이언트에서 쿠키 요청 허용
         configuration.addExposedHeader("Authorization"); // 헤더로 Authorization
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/bungaebowling/server/post/controller/PostController.java
+++ b/src/main/java/com/bungaebowling/server/post/controller/PostController.java
@@ -61,7 +61,7 @@ public class PostController {
             @RequestBody @Valid PostRequest.CreatePostDto request,
             Errors errors
     ) {
-        PostResponse.GetPostPostDto response = postService.createPostWithApplicant(userDetails.getId(), request);
+        PostResponse.CreateDto response = postService.createPostWithApplicant(userDetails.getId(), request);
 
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }

--- a/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
+++ b/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
@@ -189,6 +189,6 @@ public class PostResponse {
     }
 
     // Post시 postId 반환용
-    public record GetPostPostDto(Long id) {
+    public record CreateDto(Long id) {
     }
 }

--- a/src/main/java/com/bungaebowling/server/post/service/PostService.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostService.java
@@ -48,7 +48,7 @@ public class PostService {
     public static final int DEFAULT_SIZE = 20;
 
     @Transactional
-    public PostResponse.GetPostPostDto createPostWithApplicant(Long userId, PostRequest.CreatePostDto request) {
+    public PostResponse.CreateDto createPostWithApplicant(Long userId, PostRequest.CreatePostDto request) {
 
         User user = findUserById(userId);
 
@@ -58,7 +58,7 @@ public class PostService {
 
         saveApplicant(savedPost, user);
 
-        return new PostResponse.GetPostPostDto(savedPost.getId());
+        return new PostResponse.CreateDto(savedPost.getId());
     }
 
     private Post savePost(User user, Long districtId, PostRequest.CreatePostDto request) {

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -47,7 +47,7 @@ bungaebowling:
     refresh: 2592000
   secret: ${TOKEN_SECRET}
   domain: ${DOMAIN}
-  api_server_api: ${API_SERVER_URL}
+  api_server_url: ${API_SERVER_URL}
 
 # gmail smtp config
 mail:

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -47,6 +47,7 @@ bungaebowling:
     refresh: 2592000
   secret: ${TOKEN_SECRET}
   domain: ${DOMAIN}
+  api_server_api: ${API_SERVER_URL}
 
 # gmail smtp config
 mail:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -53,6 +53,7 @@ bungaebowling:
     refresh: 2592000
   secret: ${TOKEN_SECRET}
   domain: ${DOMAIN}
+  api_server_api: ${API_SERVER_URL}
 
 # gmail smtp config
 mail:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -53,7 +53,7 @@ bungaebowling:
     refresh: 2592000
   secret: ${TOKEN_SECRET}
   domain: ${DOMAIN}
-  api_server_api: ${API_SERVER_URL}
+  api_server_url: ${API_SERVER_URL}
 
 # gmail smtp config
 mail:

--- a/src/main/resources/application-product.yml
+++ b/src/main/resources/application-product.yml
@@ -53,6 +53,7 @@ bungaebowling:
     refresh: 2592000
   secret: ${TOKEN_SECRET}
   domain: ${DOMAIN}
+  api_server_api: ${API_SERVER_URL}
 
 # gmail smtp config
 mail:

--- a/src/main/resources/application-product.yml
+++ b/src/main/resources/application-product.yml
@@ -53,7 +53,7 @@ bungaebowling:
     refresh: 2592000
   secret: ${TOKEN_SECRET}
   domain: ${DOMAIN}
-  api_server_api: ${API_SERVER_URL}
+  api_server_url: ${API_SERVER_URL}
 
 # gmail smtp config
 mail:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -54,7 +54,7 @@ bungaebowling:
     refresh: 2592000
   secret: bungaebowling
   domain: http://localhost:3000
-  api_server_api: http://localhost:8080
+  api_server_url: http://localhost:8080
 
 # gmail smtp config
 mail:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -54,6 +54,7 @@ bungaebowling:
     refresh: 2592000
   secret: bungaebowling
   domain: http://localhost:3000
+  api_server_api: http://localhost:8080
 
 # gmail smtp config
 mail:


### PR DESCRIPTION
## Summary

크램폴린을 사용하며 배포 주소가 잦게 변할 수 있으며, aws에 올라간 서버와 크램폴린에 올라간 서버에 전부 대응이 가능해야합니다. 이를 위해선 기존 하드코딩된 서버 주소 부분을 환경변수로 변경하고 환경변수로 주입하도록 변경하였습니다.

## Description

API_SERVER_URL이라는 환경변수를 만들었습니다.

window 환경에서 환경변수를 사용하기 편리하도록 build.gradle에는 .env 파일에서 직접 값을 읽는 방식으로 구현하였습니다.
- 쿠버네티스 환경에서는 .env 파일을 만들지 않고 환경변수를 등록하는 식으로 동작하기 때문에 추가적으로 환경변수를 읽고 .env가 있으면 그값을 사용하도록 구현하였습니다.
- 로컬에서 테스트하였을 때 .env가 없으면 환경변수로 등록된 값을 바탕으로 빌드되는 걸 테스트 완료하였습니다.

CORS에도 등록하였습니다. DOMAIN은 프론트(서비스 웹페이지) 주소이기 때문에 DOMAIN과 API_SERVER_URL을 둘다 등록하였습니다.

프론트 외에 API_SERVER_URL도 CORS에 등록해야하는 이유는 swagger에 백엔드 주소로 접근하기 때문입니다. swagger로 api 실행을 위해서는 백엔드의 도메인도 등록할 필요가 존재합니다.

https://server.jagaldol.dev:8080/api/docs/swagger 현재 환경변수로 동작하고 있습니다. 잘 동작하는 모습을 확인할 수 있습니다.

이번 PR 머지되면 bungae.jagaldol.dev 서버에도 동일하게 .env 세팅하도록 하겠습니다

.env에 대한 정보는 디스코드로 공유하겠습니다.