### PR TITLE
볼링장 이미지 url 수정

### DIFF
--- a/src/main/java/com/bungaebowling/server/comment/Comment.java
+++ b/src/main/java/com/bungaebowling/server/comment/Comment.java
@@ -19,6 +19,8 @@ import java.time.LocalDateTime;
 @Table(name = "comment_tb")
 public class Comment {
 
+    public static final String DELETED_COMMENT_CONTENT = "삭제된 댓글입니다.";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -65,7 +67,7 @@ public class Comment {
     }
 
     public void delete() {
-        this.content = "삭제된 댓글입니다.";
+        this.content = DELETED_COMMENT_CONTENT;
         this.user = null;
     }
 }

--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -81,6 +81,8 @@ public class CommentService {
         var post = postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
         var parent = commentRepository.findByIdAndPostIdAndParentNull(parentId, postId).orElseThrow(() -> new CustomException(ErrorCode.REPLY_TO_COMMENT_NOT_ALLOWED));
 
+        checkIsNotDeleted(parent);
+
         var comment = requestDto.createReply(user, post, parent);
 
         var savedComment = commentRepository.save(comment);
@@ -91,6 +93,8 @@ public class CommentService {
     public void edit(Long commentId, Long userId, CommentRequest.EditDto requestDto) {
         var user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         var comment = commentRepository.findById(commentId).orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        checkIsNotDeleted(comment);
 
         if (!Objects.equals(comment.getUser().getId(), user.getId())) {
             throw new CustomException(ErrorCode.COMMENT_UPDATE_PERMISSION_DENIED);
@@ -104,10 +108,16 @@ public class CommentService {
         var user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         var comment = commentRepository.findById(commentId).orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
 
+        checkIsNotDeleted(comment);
+
         if (!Objects.equals(comment.getUser().getId(), user.getId())) {
             throw new CustomException(ErrorCode.COMMENT_DELETE_PERMISSION_DENIED);
         }
 
         comment.delete();
+    }
+
+    private void checkIsNotDeleted(Comment comment) {
+        if (comment.getUser() == null) throw new CustomException(ErrorCode.COMMENT_NOT_FOUND);
     }
 }

--- a/src/main/java/com/bungaebowling/server/place/service/PlaceService.java
+++ b/src/main/java/com/bungaebowling/server/place/service/PlaceService.java
@@ -47,18 +47,13 @@ public class PlaceService {
         String districtName = getDistrictName(placeId);
         String googlePlaceId = getGooglePlaceId(name, districtName);
         String url = createPlaceUrl(googlePlaceId);
-
         String response = restTemplate.getForObject(url, String.class);
-        log.info("detail response=" + response);
         return extractPlaceDetails(response);
     }
 
     private String getGooglePlaceId(String name, String address) {
         String url = createGooglePlaceIdUrl(name, address);
-        log.info("google place id url=" + url);
-
         String response = restTemplate.getForObject(url, String.class);
-        log.info("id response=" + response);
         return extractPlaceId(response);
     }
 

--- a/src/main/java/com/bungaebowling/server/place/service/PlaceService.java
+++ b/src/main/java/com/bungaebowling/server/place/service/PlaceService.java
@@ -39,7 +39,12 @@ public class PlaceService {
 
     private final DistrictRepository districtRepository;
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate = new RestTemplate(new SimpleClientHttpRequestFactory() {
+        @Override
+        protected void prepareConnection(HttpURLConnection connection, String httpMethod) {
+            connection.setInstanceFollowRedirects(false);
+        }
+    });
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Transactional
@@ -94,14 +99,7 @@ public class PlaceService {
     }
 
     private String getRedirectedUrl(String originalUrl) {
-        RestTemplate restTemplateRedirect = new RestTemplate(new SimpleClientHttpRequestFactory() {
-            @Override
-            protected void prepareConnection(HttpURLConnection connection, String httpMethod) {
-                connection.setInstanceFollowRedirects(false);
-            }
-        });
-
-        ResponseEntity<String> response = restTemplateRedirect.exchange(originalUrl, HttpMethod.GET, null, String.class);
+        ResponseEntity<String> response = restTemplate.exchange(originalUrl, HttpMethod.GET, null, String.class);
         return response.getHeaders().getLocation() == null ? "" : response.getHeaders().getLocation().toString();
     }
 

--- a/src/main/java/com/bungaebowling/server/place/service/PlaceService.java
+++ b/src/main/java/com/bungaebowling/server/place/service/PlaceService.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -107,10 +108,11 @@ public class PlaceService {
     }
 
     private String createPlaceUrl(String placeId) {
-        return new StringBuilder(PLACES_API_URL)
-                .append("?language=ko")
-                .append("&place_id=").append(placeId)
-                .append("&key=").append(apiKey)
+        return UriComponentsBuilder.fromHttpUrl(PLACES_API_URL)
+                .queryParam("language", "ko")
+                .queryParam("place_id", placeId)
+                .queryParam("key", apiKey)
+                .build()
                 .toString();
     }
 
@@ -129,18 +131,20 @@ public class PlaceService {
             addressBuilder.append(districtName);
         }
 
-        return new StringBuilder(GEOCODING_API_URL)
-                .append("?language=ko")
-                .append("&address=").append(addressBuilder)
-                .append("&key=").append(apiKey)
+        return UriComponentsBuilder.fromHttpUrl(GEOCODING_API_URL)
+                .queryParam("language", "ko")
+                .queryParam("address", addressBuilder)
+                .queryParam("key", apiKey)
+                .build()
                 .toString();
     }
 
     private String createImageUrl(String photoReference) {
-        return new StringBuilder(PHOTO_API_URL)
-                .append("?maxwidth=400")
-                .append("&photoreference=").append(photoReference)
-                .append("&key=").append(apiKey)
+        return UriComponentsBuilder.fromHttpUrl(PHOTO_API_URL)
+                .queryParam("maxwidth", 400)
+                .queryParam("photoreference", photoReference)
+                .queryParam("key", apiKey)
+                .build()
                 .toString();
     }
 

--- a/src/main/java/com/bungaebowling/server/place/service/PlaceService.java
+++ b/src/main/java/com/bungaebowling/server/place/service/PlaceService.java
@@ -53,7 +53,7 @@ public class PlaceService {
         String googlePlaceId = getGooglePlaceId(name, districtName);
         String url = createPlaceUrl(googlePlaceId);
         String response = restTemplate.getForObject(url, String.class);
-        return extractPlaceDetails(response);
+        return extractPlaceDetails(response, name);
     }
 
     private String getGooglePlaceId(String name, String address) {
@@ -62,15 +62,20 @@ public class PlaceService {
         return extractPlaceId(response);
     }
 
-    private PlaceResponse.GetPlaceDto extractPlaceDetails(String response) {
+    private PlaceResponse.GetPlaceDto extractPlaceDetails(String response, String placeName) {
         try {
             JsonNode result = objectMapper.readTree(response).path("result");
             if (result.isEmpty()) {
                 throw new CustomException(PLACE_DETAILS_NOT_FOUND);
             }
 
-            //볼링장 이름, 주소, 전화번호
+            //볼링장 이름
             String name = result.path("name").asText();
+            if (!placeName.equals(name)) {
+                throw new CustomException(PLACE_DETAILS_NOT_FOUND);
+            }
+
+            //볼링장 주소, 전화번호
             String address = result.path("formatted_address").asText();
             String phoneNumber = result.path("formatted_phone_number").asText();
 

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
         return ResponseEntity.ok()
                 .header(JwtProvider.HEADER, responseDto.access())
                 .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-                .body(ApiUtils.success());
+                .body(ApiUtils.success(new UserResponse.CreateDto(responseDto.savedId())));
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
@@ -103,4 +103,7 @@ public class UserResponse {
             String refresh
     ) {
     }
+
+    public record CreateDto(Long id) {
+    }
 }

--- a/src/main/resources/test_db/teardown.sql
+++ b/src/main/resources/test_db/teardown.sql
@@ -725,7 +725,8 @@ INSERT INTO user_tb (name, email, password, district_id, role)
 VALUES ('김볼링', 'test@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
        ('최볼링', 'chlqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_PENDING'),
        ('이볼링', 'dlqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
-       ('박볼링', 'qkrqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
+       ('박볼링', 'qkrqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('신볼링', 'tlsqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
 
 INSERT INTO post_tb (title, user_id, district_id, start_time, due_time, content, is_close)
 VALUES ('불금 볼링 점수 내기 하실 분~', 1, 1, '2023-12-01', '2023-11-29', '볼링 점수 내기합시다.', true),
@@ -774,9 +775,15 @@ VALUES (1, 1, true),
        (3, 2, true),
        (4, 1, true);
 
-INSERT INTO comment_tb (post_id, user_id, parent_id, content)
-VALUES (1, 2, null, '저 해도 되나요?'),
-       (1, 1, 1, '신청해주세요~');
+INSERT INTO comment_tb (id, parent_id, post_id, user_id, content)
+VALUES (1, null, 1, null, '삭제된 댓글입니다.'),
+       (2, 1, 1, 1, '신청해주세요~'),
+       (3, null, 1, 3, '저 신청했어요!'),
+       (4, null, 1, 3, '확인부탁드립니다!'),
+       (5, 4, 1, 4, '이사람 조심하세요 ㄷㄷㄷ'),
+       (6, 4, 1, 4, '저번에 신청하고 날랐습니다'),
+       (7, null, 1, 5, '아직 자리 있나요?'),
+       (8, 7, 1, 1, '네 있습니다');
 
 -- 해당 post에 신청 수락되어야함 / 모집완료(is_close)되고 start가 지난 post에만 score 등록 /
 INSERT INTO score_tb (user_id, post_id, score_num)

--- a/src/test/java/com/bungaebowling/server/_core/commons/ApiTag.java
+++ b/src/test/java/com/bungaebowling/server/_core/commons/ApiTag.java
@@ -1,4 +1,4 @@
-package com.bungaebowling.server;
+package com.bungaebowling.server._core.commons;
 
 public enum ApiTag {
     AUTHORIZATION("회원가입 로그인 인증"),

--- a/src/test/java/com/bungaebowling/server/_core/commons/GeneralApiResponseSchema.java
+++ b/src/test/java/com/bungaebowling/server/_core/commons/GeneralApiResponseSchema.java
@@ -1,4 +1,4 @@
-package com.bungaebowling.server;
+package com.bungaebowling.server._core.commons;
 
 import com.epages.restdocs.apispec.FieldDescriptors;
 import com.epages.restdocs.apispec.SimpleType;

--- a/src/test/java/com/bungaebowling/server/_core/commons/GeneralApiResponseSchema.java
+++ b/src/test/java/com/bungaebowling/server/_core/commons/GeneralApiResponseSchema.java
@@ -30,6 +30,15 @@ public enum GeneralApiResponseSchema {
                     fieldWithPath("response.nextCursorRequest.key").description("다음 요청 cursor의 key"),
                     fieldWithPath("response.nextCursorRequest.size").description("다음 요청 cursor의 size")
             )
+    ),
+    CREATED(
+            "생성 응답 DTO",
+            new FieldDescriptors(
+                    fieldWithPath("status").type(SimpleType.NUMBER).description("응답 상태 정보"),
+                    fieldWithPath("response").type(SimpleType.STRING).optional().description("응답 body"),
+                    fieldWithPath("errorMessage").type(SimpleType.STRING).optional().description("에러 메시지"),
+                    fieldWithPath("response.id").type(SimpleType.NUMBER).description("생성된 데이터의 id")
+            )
     );
 
     private final String name;

--- a/src/test/java/com/bungaebowling/server/_core/commons/GeneralParameters.java
+++ b/src/test/java/com/bungaebowling/server/_core/commons/GeneralParameters.java
@@ -1,0 +1,29 @@
+package com.bungaebowling.server._core.commons;
+
+import com.epages.restdocs.apispec.ParameterDescriptorWithType;
+import com.epages.restdocs.apispec.SimpleType;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+
+public enum GeneralParameters {
+    CURSOR_KEY(parameterWithName("key").optional().type(SimpleType.NUMBER)
+            .description("""
+                    검색 기준 id
+                                                                    
+                    처음 요청 시 key 없이 요청 | 2번째 요청부터는 response.nextCursorRequest.key 값으로 요청
+                                                                    
+                    더이상 가져올 값이 없을 시 nextCursorRequest.key로 -1 응답
+                    """)),
+    SIZE(parameterWithName("size").optional().type(SimpleType.NUMBER).defaultValue(20).description("한번에 가져올 크기"));
+
+
+    private final ParameterDescriptorWithType parameterDescriptorWithType;
+
+    public ParameterDescriptorWithType getParameterDescriptorWithType() {
+        return parameterDescriptorWithType;
+    }
+
+    GeneralParameters(ParameterDescriptorWithType responseDescriptor) {
+        this.parameterDescriptorWithType = responseDescriptor;
+    }
+}

--- a/src/test/java/com/bungaebowling/server/city/controller/CityControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/city/controller/CityControllerTest.java
@@ -1,8 +1,8 @@
 package com.bungaebowling.server.city.controller;
 
-import com.bungaebowling.server.ApiTag;
 import com.bungaebowling.server.ControllerTestConfig;
-import com.bungaebowling.server.GeneralApiResponseSchema;
+import com.bungaebowling.server._core.commons.ApiTag;
+import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -1,0 +1,190 @@
+package com.bungaebowling.server.comment.controller;
+
+import com.bungaebowling.server.ControllerTestConfig;
+import com.bungaebowling.server._core.commons.ApiTag;
+import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
+import com.bungaebowling.server._core.commons.GeneralParameters;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.context.WebApplicationContext;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@ActiveProfiles(value = {"test"})
+@Sql(value = "classpath:test_db/teardown.sql", config = @SqlConfig(encoding = "UTF-8"))
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class CommentControllerTest extends ControllerTestConfig {
+
+    @Autowired
+    public CommentControllerTest(WebApplicationContext context, ObjectMapper om) {
+        super(context, om);
+    }
+
+    @Test
+    @DisplayName("댓글 조회 테스트")
+    void getComments() throws Exception {
+        // given
+        Long postId = 1L;
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .get("/api/posts/{postId}/comments", postId)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200),
+                jsonPath("$.response.nextCursorRequest").exists(),
+                jsonPath("$.response.comments[*].id", everyItem(isA(Integer.class))),
+                jsonPath("$.response.comments[*].userId").hasJsonPath(),
+                jsonPath("$.response.comments[*].userName").hasJsonPath(),
+                jsonPath("$.response.comments[*].profileImage").hasJsonPath(),
+                jsonPath("$.response.comments[*].content", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].createdAt", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].editedAt", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].childComments[*].id", everyItem(isA(Integer.class))),
+                jsonPath("$.response.comments[*].childComments[*].userId", everyItem(isA(Integer.class))),
+                jsonPath("$.response.comments[*].childComments[*].userName", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].childComments[*].profileImage").hasJsonPath(),
+                jsonPath("$.response.comments[*].childComments[*].content", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].childComments[*].createdAt", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].childComments[*].editedAt", everyItem(notNullValue()))
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] getComments",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("댓글 조회")
+                                        .description("""
+                                                모집글의 댓글들을 조회합니다.
+                                                                                                
+                                                기본적으로 **삭제된 댓글은 보이지 않**습니다.
+                                                                                                
+                                                삭제된 댓글이 대댓글을 가지고 있는 경우만 출력이 되며 이때 댓글은 아래와 같이 응답되게 됩니다.
+                                                - userId, userName -> null
+                                                - content -> "삭제된 댓글입니다."
+                                                                                                
+                                                size에는 삭제된 댓글의 수가 함께 집계되기 때문에 응답에는 없지만 개수로 포함될 수 있습니다. 따라서 **설정한 size 수(default 20)보다 적은 수의 댓글이 응답될 수** 있습니다.
+                                                """)
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .pathParameters(parameterWithName("postId").description("조회할 댓글들의 모집글 id"))
+                                        .responseSchema(Schema.schema("댓글 조회 응답 DTO"))
+                                        .responseFields(
+                                                GeneralApiResponseSchema.NEXT_CURSOR.getResponseDescriptor().and(
+                                                        fieldWithPath("response.comments[].id").description("댓글의 ID(PK)"),
+                                                        fieldWithPath("response.comments").description("댓글"),
+                                                        fieldWithPath("response.comments[].userId").optional().type(SimpleType.NUMBER).description("댓글 작성자의 ID(PK) | 삭제된 댓글의 경우 null"),
+                                                        fieldWithPath("response.comments[].userName").optional().type(SimpleType.STRING).description("댓글 작성자의 닉네임 | 삭제된 댓글의 경우 null"),
+                                                        fieldWithPath("response.comments[].profileImage").optional().type(SimpleType.STRING).description("댓글 작성자 프로필 이미지 경로"),
+                                                        fieldWithPath("response.comments[].content").description("댓글 내용 | 삭제된 댓글의 경우 '삭제된 댓글입니다.'"),
+                                                        fieldWithPath("response.comments[].createdAt").description("댓글 생성 시간"),
+                                                        fieldWithPath("response.comments[].editedAt").description("댓글 마지막 수정 시간"),
+                                                        fieldWithPath("response.comments[].childComments").description("대댓글"),
+                                                        fieldWithPath("response.comments[].childComments[].id").description("대댓글 ID"),
+                                                        fieldWithPath("response.comments[].childComments[].userId").description("대댓글 작성자의 ID(PK)"),
+                                                        fieldWithPath("response.comments[].childComments[].userName").description("대댓글 작성자의 닉네임"),
+                                                        fieldWithPath("response.comments[].childComments[].profileImage").description("대댓글 작성자 프로필 이미지 경로"),
+                                                        fieldWithPath("response.comments[].childComments[].content").description("대댓글 내용"),
+                                                        fieldWithPath("response.comments[].childComments[].createdAt").description("대댓글 생성 시간"),
+                                                        fieldWithPath("response.comments[].childComments[].editedAt").description("대댓글 마지막 수정 시간")
+                                                )
+                                        )
+                                        .build()
+                        )
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("댓글 조회 테스트 - key, size 검색")
+    void getCommentsWithPage() throws Exception {
+        // given
+        Long postId = 1L;
+        int size = 2;
+        int key = 1;
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .get("/api/posts/{postId}/comments", postId)
+                        .param("key", Integer.toString(key))
+                        .param("size", Integer.toString(size))
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200),
+                jsonPath("$.response.comments[0].id").value(greaterThan(key)),
+                jsonPath("$.response.comments").value(hasSize(lessThanOrEqualTo(size)))
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] getCommentsWithPage",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .pathParameters(parameterWithName("postId").description("조회할 댓글들의 모집글 id"))
+                                        .queryParameters(
+                                                GeneralParameters.CURSOR_KEY.getParameterDescriptorWithType(),
+                                                GeneralParameters.SIZE.getParameterDescriptorWithType()
+                                        )
+                                        .build()
+                        )
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("댓글 등록 테스트")
+    void create() throws Exception {
+    }
+
+    @Test
+    @DisplayName("대댓글 등록 테스트")
+    void createReply() throws Exception {
+    }
+
+    @Test
+    @DisplayName("댓글 수정 테스트")
+    void edit() throws Exception {
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 테스트")
+    void delete() throws Exception {
+    }
+}

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -4,16 +4,26 @@ import com.bungaebowling.server.ControllerTestConfig;
 import com.bungaebowling.server._core.commons.ApiTag;
 import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
 import com.bungaebowling.server._core.commons.GeneralParameters;
+import com.bungaebowling.server._core.errors.exception.ErrorCode;
+import com.bungaebowling.server._core.security.JwtProvider;
+import com.bungaebowling.server.comment.Comment;
+import com.bungaebowling.server.comment.dto.CommentRequest;
+import com.bungaebowling.server.comment.repository.CommentRepository;
+import com.bungaebowling.server.user.Role;
+import com.bungaebowling.server.user.User;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
@@ -21,8 +31,7 @@ import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.context.WebApplicationContext;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -35,9 +44,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 class CommentControllerTest extends ControllerTestConfig {
 
+    private final CommentRepository commentRepository;
+
     @Autowired
-    public CommentControllerTest(WebApplicationContext context, ObjectMapper om) {
+    public CommentControllerTest(WebApplicationContext context, ObjectMapper om, CommentRepository commentRepository) {
         super(context, om);
+        this.commentRepository = commentRepository;
     }
 
     @Test
@@ -90,10 +102,10 @@ class CommentControllerTest extends ControllerTestConfig {
                                                                                                 
                                                 삭제된 댓글이 대댓글을 가지고 있는 경우만 출력이 되며 이때 댓글은 아래와 같이 응답되게 됩니다.
                                                 - userId, userName -> null
-                                                - content -> "삭제된 댓글입니다."
+                                                - content -> "%s"
                                                                                                 
                                                 size에는 삭제된 댓글의 수가 함께 집계되기 때문에 응답에는 없지만 개수로 포함될 수 있습니다. 따라서 **설정한 size 수(default 20)보다 적은 수의 댓글이 응답될 수** 있습니다.
-                                                """)
+                                                """.formatted(Comment.DELETED_COMMENT_CONTENT))
                                         .tag(ApiTag.COMMENT.getTagName())
                                         .pathParameters(parameterWithName("postId").description("조회할 댓글들의 모집글 id"))
                                         .responseSchema(Schema.schema("댓글 조회 응답 DTO"))
@@ -104,7 +116,7 @@ class CommentControllerTest extends ControllerTestConfig {
                                                         fieldWithPath("response.comments[].userId").optional().type(SimpleType.NUMBER).description("댓글 작성자의 ID(PK) | 삭제된 댓글의 경우 null"),
                                                         fieldWithPath("response.comments[].userName").optional().type(SimpleType.STRING).description("댓글 작성자의 닉네임 | 삭제된 댓글의 경우 null"),
                                                         fieldWithPath("response.comments[].profileImage").optional().type(SimpleType.STRING).description("댓글 작성자 프로필 이미지 경로"),
-                                                        fieldWithPath("response.comments[].content").description("댓글 내용 | 삭제된 댓글의 경우 '삭제된 댓글입니다.'"),
+                                                        fieldWithPath("response.comments[].content").description("댓글 내용 | 삭제된 댓글의 경우 '%s'".formatted(Comment.DELETED_COMMENT_CONTENT)),
                                                         fieldWithPath("response.comments[].createdAt").description("댓글 생성 시간"),
                                                         fieldWithPath("response.comments[].editedAt").description("댓글 마지막 수정 시간"),
                                                         fieldWithPath("response.comments[].childComments").description("대댓글"),
@@ -171,20 +183,441 @@ class CommentControllerTest extends ControllerTestConfig {
     @Test
     @DisplayName("댓글 등록 테스트")
     void create() throws Exception {
+        // given
+        Long postId = 1L;
+
+        var userId = 1L;
+
+        var accessToken = JwtProvider.createAccess(
+                User.builder()
+                        .id(userId)
+                        .role(Role.ROLE_USER)
+                        .build()
+        ); // 김볼링
+
+        var requestDto = new CommentRequest.CreateDto("안녕하세요");
+        String requestBody = om.writeValueAsString(requestDto);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .post("/api/posts/{postId}/comments", postId)
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200),
+                jsonPath("$.response.id").isNumber()
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("댓글 등록")
+                                        .description("""
+                                                모집글에 새로운 댓글을 등록합니다.
+                                                                                                
+                                                대댓글 등록은 별개의 api를 사용해주세요.
+                                                """)
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(parameterWithName("postId").description("댓글을 등록할 모집글 id"))
+                                        .requestSchema(Schema.schema("댓글 등록 요청 DTO"))
+                                        .requestFields(fieldWithPath("content").description("등록할 댓글 내용"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.CREATED.getName()))
+                                        .responseFields(GeneralApiResponseSchema.CREATED.getResponseDescriptor())
+                                        .build()
+                        )
+                )
+        );
     }
 
     @Test
     @DisplayName("대댓글 등록 테스트")
     void createReply() throws Exception {
+        // given
+        var postId = 1L;
+
+        var parentCommentId = 3L;
+
+        var userId = 1L;
+
+        var accessToken = JwtProvider.createAccess(
+                User.builder()
+                        .id(userId)
+                        .role(Role.ROLE_USER)
+                        .build()
+        ); // 김볼링
+
+        var requestDto = new CommentRequest.CreateDto("확인 해볼게요!");
+        String requestBody = om.writeValueAsString(requestDto);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .post("/api/posts/{postId}/comments/{commentId}/reply", postId, parentCommentId)
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200),
+                jsonPath("$.response.id").isNumber()
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] createReply",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("대댓글 등록")
+                                        .description("""
+                                                댓글에 대댓글을 등록합니다.
+                                                """)
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(
+                                                parameterWithName("postId").description("대댓글을 등록할 모집글 id"),
+                                                parameterWithName("commentId").description("대댓글을 등록할 댓글 id")
+                                        )
+                                        .requestSchema(Schema.schema("댓글 등록 요청 DTO"))
+                                        .requestFields(fieldWithPath("content").description("등록할 댓글 내용"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.CREATED.getName()))
+                                        .responseFields(GeneralApiResponseSchema.CREATED.getResponseDescriptor())
+                                        .build()
+                        )
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("대댓글 등록 테스트 - 삭제된 댓글에 시도")
+    void createReplyAtDeleted() throws Exception {
+        // given
+        var postId = 1L;
+
+        var parentCommentId = 1L;
+
+        var userId = 1L;
+
+        var accessToken = JwtProvider.createAccess(
+                User.builder()
+                        .id(userId)
+                        .role(Role.ROLE_USER)
+                        .build()
+        ); // 김볼링
+
+        var requestDto = new CommentRequest.CreateDto("확인 해볼게요!");
+        String requestBody = om.writeValueAsString(requestDto);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .post("/api/posts/{postId}/comments/{commentId}/reply", postId, parentCommentId)
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+
+        resultActions.andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.status").value(404),
+                jsonPath("$.response").value(ErrorCode.COMMENT_NOT_FOUND.toString())
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] createReplyAtDeleted",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(
+                                                parameterWithName("postId").description("대댓글을 등록할 모집글 id"),
+                                                parameterWithName("commentId").description("대댓글을 등록할 댓글 id")
+                                        )
+                                        .requestSchema(Schema.schema("댓글 등록 요청 DTO"))
+                                        .requestFields(fieldWithPath("content").description("등록할 댓글 내용"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.FAIL.getName()))
+                                        .responseFields(GeneralApiResponseSchema.FAIL.getResponseDescriptor())
+                                        .build()
+                        )
+                )
+        );
     }
 
     @Test
     @DisplayName("댓글 수정 테스트")
     void edit() throws Exception {
+        // given
+        var postId = 1L;
+
+        var commentId = 3L;
+
+        var userId = 3L; // 이볼링
+
+        var accessToken = JwtProvider.createAccess(
+                User.builder()
+                        .id(userId)
+                        .role(Role.ROLE_USER)
+                        .build()
+        );
+
+        var content = "아 그냥 취소할게요";
+
+        var requestDto = new CommentRequest.EditDto(content);
+        String requestBody = om.writeValueAsString(requestDto);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .put("/api/posts/{postId}/comments/{commentId}", postId, commentId)
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+        var modifiedComment = commentRepository.findById(commentId).orElse(null);
+
+        Assertions.assertNotNull(modifiedComment);
+        Assertions.assertEquals(modifiedComment.getUser().getId(), userId);
+        Assertions.assertEquals(modifiedComment.getContent(), content);
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200)
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] edit",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("댓글 수정")
+                                        .description("""
+                                                댓글을 수정합니다.(대댓글의 경우도 commentId를 사용하여 해당 api를 사용합니다.)
+                                                """)
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(
+                                                parameterWithName("postId").description("댓글을 수정할 모집글 id"),
+                                                parameterWithName("commentId").description("수정할 댓글 id")
+                                        )
+                                        .requestSchema(Schema.schema("댓글 수정 요청 DTO"))
+                                        .requestFields(fieldWithPath("content").description("수정할 댓글 내용"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.SUCCESS.getName()))
+                                        .responseFields(GeneralApiResponseSchema.SUCCESS.getResponseDescriptor())
+                                        .build()
+                        )
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("댓글 수정 테스트 - 자신의 댓글이 아님")
+    void editNotMyComment() throws Exception {
+        // given
+        var postId = 1L;
+
+        var commentId = 2L;
+
+        var userId = 3L; // 이볼링
+
+        var accessToken = JwtProvider.createAccess(
+                User.builder()
+                        .id(userId)
+                        .role(Role.ROLE_USER)
+                        .build()
+        );
+
+        var requestDto = new CommentRequest.EditDto("아 그냥 취소할게요");
+        String requestBody = om.writeValueAsString(requestDto);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .put("/api/posts/{postId}/comments/{commentId}", postId, commentId)
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+
+        resultActions.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.response").value(ErrorCode.COMMENT_UPDATE_PERMISSION_DENIED.toString())
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] editNotMyComment",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(
+                                                parameterWithName("postId").description("댓글을 수정할 모집글 id"),
+                                                parameterWithName("commentId").description("수정할 댓글 id")
+                                        )
+                                        .requestSchema(Schema.schema("댓글 수정 요청 DTO"))
+                                        .requestFields(fieldWithPath("content").description("수정할 댓글 내용"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.FAIL.getName()))
+                                        .responseFields(GeneralApiResponseSchema.FAIL.getResponseDescriptor())
+                                        .build()
+                        )
+                )
+        );
     }
 
     @Test
     @DisplayName("댓글 삭제 테스트")
     void delete() throws Exception {
+        // given
+        var postId = 1L;
+
+        var commentId = 2L;
+
+        var userId = 1L; // 김볼링
+
+        var accessToken = JwtProvider.createAccess(
+                User.builder()
+                        .id(userId)
+                        .role(Role.ROLE_USER)
+                        .build()
+        );
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .delete("/api/posts/{postId}/comments/{commentId}", postId, commentId)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+        var modifiedComment = commentRepository.findById(commentId).orElse(null);
+
+        Assertions.assertNotNull(modifiedComment);
+        Assertions.assertNull(modifiedComment.getUser());
+        Assertions.assertEquals(modifiedComment.getContent(), Comment.DELETED_COMMENT_CONTENT);
+
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200)
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("댓글 삭제")
+                                        .description("""
+                                                댓글을 삭제합니다.(대댓글의 경우도 commentId를 사용하여 해당 api를 사용합니다.)
+                                                                                                
+                                                삭제된 댓글이 대댓글을 가지고 있던 경우, 댓글 조회 api 호출 시 내용과 작성자가 지워진 채로 조회가 됩니다.
+                                                - userId, userName -> null
+                                                - content -> "%s"
+                                                """)
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(
+                                                parameterWithName("postId").description("댓글을 삭제할 모집글 id"),
+                                                parameterWithName("commentId").description("삭제할 댓글 id")
+                                        )
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.SUCCESS.getName()))
+                                        .responseFields(GeneralApiResponseSchema.SUCCESS.getResponseDescriptor())
+                                        .build()
+                        )
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 테스트 - 자신의 댓글이 아님")
+    void deleteNotMyComment() throws Exception {
+        // given
+        var postId = 1L;
+
+        var commentId = 3L;
+
+        var userId = 1L; // 김볼링
+
+        var accessToken = JwtProvider.createAccess(
+                User.builder()
+                        .id(userId)
+                        .role(Role.ROLE_USER)
+                        .build()
+        );
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .delete("/api/posts/{postId}/comments/{commentId}", postId, commentId)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+
+        resultActions.andExpectAll(
+                status().isForbidden(),
+                jsonPath("$.status").value(403),
+                jsonPath("$.response").value(ErrorCode.COMMENT_DELETE_PERMISSION_DENIED.toString())
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] editNotMyComment",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(
+                                                parameterWithName("postId").description("댓글을 삭제할 모집글 id"),
+                                                parameterWithName("commentId").description("삭제할 댓글 id")
+                                        )
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.FAIL.getName()))
+                                        .responseFields(GeneralApiResponseSchema.FAIL.getResponseDescriptor())
+                                        .build()
+                        )
+                )
+        );
     }
 }

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -110,7 +110,8 @@ class UserControllerTest extends ControllerTestConfig {
 
         resultActions.andExpectAll(
                 status().isOk(),
-                jsonPath("$.status").value(200)
+                jsonPath("$.status").value(200),
+                jsonPath("$.response.id").isNumber()
         ).andDo(
                 MockMvcRestDocumentationWrapper.document(
                         "[user] join",
@@ -143,8 +144,8 @@ class UserControllerTest extends ControllerTestConfig {
 
                                                         (e.g.)Bearer {jwt_access_token}""")
                                         )
-                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.SUCCESS.getName()))
-                                        .responseFields(GeneralApiResponseSchema.SUCCESS.getResponseDescriptor())
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.CREATED.getName()))
+                                        .responseFields(GeneralApiResponseSchema.CREATED.getResponseDescriptor())
                                         .build()
                         )
                 )


### PR DESCRIPTION
## Summary

볼링장 상세 조회 api 에서 image를 넘겨줄 때 초기 요청 url에 google photo api key가 같이 전달됩니다. 구글 측에서 api key를 노출시키지 않는 url로 리다이렉트 시켜서 사용자에게 보여주기 때문에 리다이렉트된 이후 url을 가져와서 api key를 노출시키지 않도록 합니다.

## Description

getRedirectedUrl()에서 리다이렉트된 url을 가져옵니다. response header를 받아와야 하기 때문에 get 대신 exchange 메소드를 사용했습니다. http redirect를 비활성화해서 최종 목적지 200 response가 아닌 302 response를 가져오도록 설정합니다. 302의 response header에서 location을 가져와서 반환합니다. 

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #106 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->