### PR TITLE
댓글 조회 테스트 코드 작성 및 문서화 + 기타 버그 수정

### DIFF
--- a/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
+++ b/src/main/java/com/bungaebowling/server/comment/service/CommentService.java
@@ -81,6 +81,8 @@ public class CommentService {
         var post = postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
         var parent = commentRepository.findByIdAndPostIdAndParentNull(parentId, postId).orElseThrow(() -> new CustomException(ErrorCode.REPLY_TO_COMMENT_NOT_ALLOWED));
 
+        checkIsNotDeleted(parent);
+
         var comment = requestDto.createReply(user, post, parent);
 
         var savedComment = commentRepository.save(comment);
@@ -91,6 +93,8 @@ public class CommentService {
     public void edit(Long commentId, Long userId, CommentRequest.EditDto requestDto) {
         var user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         var comment = commentRepository.findById(commentId).orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        checkIsNotDeleted(comment);
 
         if (!Objects.equals(comment.getUser().getId(), user.getId())) {
             throw new CustomException(ErrorCode.COMMENT_UPDATE_PERMISSION_DENIED);
@@ -104,10 +108,16 @@ public class CommentService {
         var user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         var comment = commentRepository.findById(commentId).orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
 
+        checkIsNotDeleted(comment);
+
         if (!Objects.equals(comment.getUser().getId(), user.getId())) {
             throw new CustomException(ErrorCode.COMMENT_DELETE_PERMISSION_DENIED);
         }
 
         comment.delete();
+    }
+
+    private void checkIsNotDeleted(Comment comment) {
+        if (comment.getUser() == null) throw new CustomException(ErrorCode.COMMENT_NOT_FOUND);
     }
 }

--- a/src/main/resources/test_db/teardown.sql
+++ b/src/main/resources/test_db/teardown.sql
@@ -725,7 +725,8 @@ INSERT INTO user_tb (name, email, password, district_id, role)
 VALUES ('김볼링', 'test@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
        ('최볼링', 'chlqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_PENDING'),
        ('이볼링', 'dlqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
-       ('박볼링', 'qkrqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
+       ('박볼링', 'qkrqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER'),
+       ('신볼링', 'tlsqhffld@test.com', '{bcrypt}$2a$10$yK46P9/7TyA2J4z69uEEhOdInb6a7lgHNWVfqftsQSwvLgwSZv9Mq', 1, 'ROLE_USER');
 
 INSERT INTO post_tb (title, user_id, district_id, start_time, due_time, content, is_close)
 VALUES ('불금 볼링 점수 내기 하실 분~', 1, 1, '2023-12-01', '2023-11-29', '볼링 점수 내기합시다.', true),
@@ -774,9 +775,15 @@ VALUES (1, 1, true),
        (3, 2, true),
        (4, 1, true);
 
-INSERT INTO comment_tb (post_id, user_id, parent_id, content)
-VALUES (1, 2, null, '저 해도 되나요?'),
-       (1, 1, 1, '신청해주세요~');
+INSERT INTO comment_tb (id, parent_id, post_id, user_id, content)
+VALUES (1, null, 1, null, '삭제된 댓글입니다.'),
+       (2, 1, 1, 1, '신청해주세요~'),
+       (3, null, 1, 3, '저 신청했어요!'),
+       (4, null, 1, 3, '확인부탁드립니다!'),
+       (5, 4, 1, 4, '이사람 조심하세요 ㄷㄷㄷ'),
+       (6, 4, 1, 4, '저번에 신청하고 날랐습니다'),
+       (7, null, 1, 5, '아직 자리 있나요?'),
+       (8, 7, 1, 1, '네 있습니다');
 
 -- 해당 post에 신청 수락되어야함 / 모집완료(is_close)되고 start가 지난 post에만 score 등록 /
 INSERT INTO score_tb (user_id, post_id, score_num)

--- a/src/test/java/com/bungaebowling/server/_core/commons/ApiTag.java
+++ b/src/test/java/com/bungaebowling/server/_core/commons/ApiTag.java
@@ -1,4 +1,4 @@
-package com.bungaebowling.server;
+package com.bungaebowling.server._core.commons;
 
 public enum ApiTag {
     AUTHORIZATION("회원가입 로그인 인증"),

--- a/src/test/java/com/bungaebowling/server/_core/commons/GeneralApiResponseSchema.java
+++ b/src/test/java/com/bungaebowling/server/_core/commons/GeneralApiResponseSchema.java
@@ -1,4 +1,4 @@
-package com.bungaebowling.server;
+package com.bungaebowling.server._core.commons;
 
 import com.epages.restdocs.apispec.FieldDescriptors;
 import com.epages.restdocs.apispec.SimpleType;

--- a/src/test/java/com/bungaebowling/server/_core/commons/GeneralParameters.java
+++ b/src/test/java/com/bungaebowling/server/_core/commons/GeneralParameters.java
@@ -1,0 +1,29 @@
+package com.bungaebowling.server._core.commons;
+
+import com.epages.restdocs.apispec.ParameterDescriptorWithType;
+import com.epages.restdocs.apispec.SimpleType;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+
+public enum GeneralParameters {
+    CURSOR_KEY(parameterWithName("key").optional().type(SimpleType.NUMBER)
+            .description("""
+                    검색 기준 id
+                                                                    
+                    처음 요청 시 key 없이 요청 | 2번째 요청부터는 response.nextCursorRequest.key 값으로 요청
+                                                                    
+                    더이상 가져올 값이 없을 시 nextCursorRequest.key로 -1 응답
+                    """)),
+    SIZE(parameterWithName("size").optional().type(SimpleType.NUMBER).defaultValue(20).description("한번에 가져올 크기"));
+
+
+    private final ParameterDescriptorWithType parameterDescriptorWithType;
+
+    public ParameterDescriptorWithType getParameterDescriptorWithType() {
+        return parameterDescriptorWithType;
+    }
+
+    GeneralParameters(ParameterDescriptorWithType responseDescriptor) {
+        this.parameterDescriptorWithType = responseDescriptor;
+    }
+}

--- a/src/test/java/com/bungaebowling/server/city/controller/CityControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/city/controller/CityControllerTest.java
@@ -1,8 +1,8 @@
 package com.bungaebowling.server.city.controller;
 
-import com.bungaebowling.server.ApiTag;
 import com.bungaebowling.server.ControllerTestConfig;
-import com.bungaebowling.server.GeneralApiResponseSchema;
+import com.bungaebowling.server._core.commons.ApiTag;
+import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -1,6 +1,12 @@
 package com.bungaebowling.server.comment.controller;
 
+import com.bungaebowling.server.ApiTag;
 import com.bungaebowling.server.ControllerTestConfig;
+import com.bungaebowling.server.GeneralApiResponseSchema;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,7 +20,11 @@ import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.context.WebApplicationContext;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.hamcrest.Matchers.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -64,6 +74,43 @@ class CommentControllerTest extends ControllerTestConfig {
                 jsonPath("$.response.comments[*].childComments[*].content", everyItem(notNullValue())),
                 jsonPath("$.response.comments[*].childComments[*].createdAt", everyItem(notNullValue())),
                 jsonPath("$.response.comments[*].childComments[*].editedAt", everyItem(notNullValue()))
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] getComments",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("댓글 조회")
+                                        .description("""
+                                                모집글의 댓글들을 조회합니다.
+                                                """)
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .pathParameters(parameterWithName("postId").description("조회할 댓글들의 모집글 id"))
+                                        .responseSchema(Schema.schema("댓글 조회 응답 DTO"))
+                                        .responseFields(
+                                                GeneralApiResponseSchema.NEXT_CURSOR.getResponseDescriptor().and(
+                                                        fieldWithPath("response.comments[].id").description("댓글의 ID(PK)"),
+                                                        fieldWithPath("response.comments").description("댓글"),
+                                                        fieldWithPath("response.comments[].userId").optional().type(SimpleType.NUMBER).description("댓글 작성자의 ID(PK) | 삭제된 댓글의 경우 null"),
+                                                        fieldWithPath("response.comments[].userName").optional().type(SimpleType.STRING).description("댓글 작성자의 닉네임 | 삭제된 댓글의 경우 null"),
+                                                        fieldWithPath("response.comments[].profileImage").optional().type(SimpleType.STRING).description("댓글 작성자 프로필 이미지 경로"),
+                                                        fieldWithPath("response.comments[].content").description("댓글 내용 | 삭제된 댓글의 경우 '삭제된 댓글입니다.'"),
+                                                        fieldWithPath("response.comments[].createdAt").description("댓글 생성 시간"),
+                                                        fieldWithPath("response.comments[].editedAt").description("댓글 마지막 수정 시간"),
+                                                        fieldWithPath("response.comments[].childComments").description("대댓글"),
+                                                        fieldWithPath("response.comments[].childComments[].id").description("대댓글 ID"),
+                                                        fieldWithPath("response.comments[].childComments[].userId").description("대댓글 작성자의 ID(PK)"),
+                                                        fieldWithPath("response.comments[].childComments[].userName").description("대댓글 작성자의 닉네임"),
+                                                        fieldWithPath("response.comments[].childComments[].profileImage").description("대댓글 작성자 프로필 이미지 경로"),
+                                                        fieldWithPath("response.comments[].childComments[].content").description("대댓글 내용"),
+                                                        fieldWithPath("response.comments[].childComments[].createdAt").description("대댓글 생성 시간"),
+                                                        fieldWithPath("response.comments[].childComments[].editedAt").description("대댓글 마지막 수정 시간")
+                                                )
+                                        )
+                                        .build()
+                        )
+                )
         );
     }
 

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -1,8 +1,8 @@
 package com.bungaebowling.server.comment.controller;
 
-import com.bungaebowling.server.ApiTag;
 import com.bungaebowling.server.ControllerTestConfig;
-import com.bungaebowling.server.GeneralApiResponseSchema;
+import com.bungaebowling.server._core.commons.ApiTag;
+import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -3,6 +3,7 @@ package com.bungaebowling.server.comment.controller;
 import com.bungaebowling.server.ControllerTestConfig;
 import com.bungaebowling.server._core.commons.ApiTag;
 import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
+import com.bungaebowling.server._core.commons.GeneralParameters;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -150,15 +151,8 @@ class CommentControllerTest extends ControllerTestConfig {
                                         .tag(ApiTag.COMMENT.getTagName())
                                         .pathParameters(parameterWithName("postId").description("조회할 댓글들의 모집글 id"))
                                         .queryParameters(
-                                                parameterWithName("key").optional().type(SimpleType.NUMBER)
-                                                        .description("""
-                                                                검색 기준 id
-                                                                                                                
-                                                                처음 요청 시 key 없이 요청 | 2번째 요청부터는 response.nextCursorRequest.key 값으로 요청
-                                                                                                                
-                                                                더이상 가져올 값이 없을 시 nextCursorRequest.key로 -1 응답
-                                                                """),
-                                                parameterWithName("size").optional().type(SimpleType.NUMBER).defaultValue(20).description("한번에 가져올 크기")
+                                                GeneralParameters.CURSOR_KEY.getParameterDescriptorWithType(),
+                                                GeneralParameters.SIZE.getParameterDescriptorWithType()
                                         )
                                         .build()
                         )

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -85,6 +85,14 @@ class CommentControllerTest extends ControllerTestConfig {
                                         .summary("댓글 조회")
                                         .description("""
                                                 모집글의 댓글들을 조회합니다.
+                                                                                                
+                                                기본적으로 **삭제된 댓글은 보이지 않**습니다.
+                                                                                                
+                                                삭제된 댓글이 대댓글을 가지고 있는 경우만 출력이 되며 이때 댓글은 아래와 같이 응답되게 됩니다.
+                                                - userId, userName -> null
+                                                - content -> "삭제된 댓글입니다."
+                                                                                                
+                                                size에는 삭제된 댓글의 수가 함께 집계되기 때문에 응답에는 없지만 개수로 포함될 수 있습니다. 따라서 **설정한 size 수(default 20)보다 적은 수의 댓글이 응답될 수** 있습니다.
                                                 """)
                                         .tag(ApiTag.COMMENT.getTagName())
                                         .pathParameters(parameterWithName("postId").description("조회할 댓글들의 모집글 id"))

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -1,0 +1,50 @@
+package com.bungaebowling.server.comment.controller;
+
+import com.bungaebowling.server.ControllerTestConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.web.context.WebApplicationContext;
+
+@AutoConfigureMockMvc
+@ActiveProfiles(value = {"test"})
+@Sql(value = "classpath:test_db/teardown.sql", config = @SqlConfig(encoding = "UTF-8"))
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class CommentControllerTest extends ControllerTestConfig {
+
+    @Autowired
+    public CommentControllerTest(WebApplicationContext context, ObjectMapper om) {
+        super(context, om);
+    }
+
+    @Test
+    @DisplayName("댓글 조회 테스트")
+    void getComments() throws Exception {
+    }
+
+    @Test
+    @DisplayName("댓글 등록 테스트")
+    void create() throws Exception {
+    }
+
+    @Test
+    @DisplayName("대댓글 등록 테스트")
+    void createReply() throws Exception {
+    }
+
+    @Test
+    @DisplayName("댓글 수정 테스트")
+    void edit() throws Exception {
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 테스트")
+    void delete() throws Exception {
+    }
+}

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -7,10 +7,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.context.WebApplicationContext;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @ActiveProfiles(value = {"test"})
@@ -26,6 +32,39 @@ class CommentControllerTest extends ControllerTestConfig {
     @Test
     @DisplayName("댓글 조회 테스트")
     void getComments() throws Exception {
+        // given
+        Long postId = 1L;
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .get("/api/posts/{postId}/comments", postId)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200),
+                jsonPath("$.response.nextCursorRequest").exists(),
+                jsonPath("$.response.comments[*].id", everyItem(isA(Integer.class))),
+                jsonPath("$.response.comments[*].userId").hasJsonPath(),
+                jsonPath("$.response.comments[*].userName").hasJsonPath(),
+                jsonPath("$.response.comments[*].profileImage").hasJsonPath(),
+                jsonPath("$.response.comments[*].content", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].createdAt", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].editedAt", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].childComments[*].id", everyItem(isA(Integer.class))),
+                jsonPath("$.response.comments[*].childComments[*].userId", everyItem(isA(Integer.class))),
+                jsonPath("$.response.comments[*].childComments[*].userName", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].childComments[*].profileImage").hasJsonPath(),
+                jsonPath("$.response.comments[*].childComments[*].content", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].childComments[*].createdAt", everyItem(notNullValue())),
+                jsonPath("$.response.comments[*].childComments[*].editedAt", everyItem(notNullValue()))
+        );
     }
 
     @Test

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -49,8 +49,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -589,6 +588,56 @@ class UserControllerTest extends ControllerTestConfig {
                                                         fieldWithPath("response.users[].rating").description("사용자의 별점"),
                                                         fieldWithPath("response.users[].profileImage").type(SimpleType.STRING).optional().description("사용자의 프로필 이미지 링크 | 이미지 설정 안한 경우 null")
                                                 )
+                                        )
+                                        .build()
+                        )
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("사용자 목록 조회 테스트 - 다음 페이지 검색")
+    void getUsersNextPage() throws Exception {
+        // given
+        int key = 25;
+        int size = 20;
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .get("/api/users")
+                        .param("key", Integer.toString(key))
+                        .param("size", Integer.toString(size))
+        );
+
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200),
+                jsonPath("$.response.users[0].id").value(lessThan(key)),
+                jsonPath("$.response.users").value(hasSize(lessThanOrEqualTo(size)))
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[user] getUsersNextPage",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(ApiTag.USER.getTagName())
+                                        .queryParameters(
+                                                parameterWithName("key").optional().type(SimpleType.NUMBER)
+                                                        .description("""
+                                                                검색 기준 id
+                                                                                                                
+                                                                처음 요청 시 key 없이 요청 | 2번째 요청부터는 response.nextCursorRequest.key 값으로 요청
+                                                                                                                
+                                                                더이상 가져올 값이 없을 시 nextCursorRequest.key로 -1 응답
+                                                                """),
+                                                parameterWithName("size").optional().type(SimpleType.NUMBER).defaultValue(20).description("한번에 가져올 크기")
                                         )
                                         .build()
                         )

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.bungaebowling.server.ControllerTestConfig;
 import com.bungaebowling.server._core.commons.ApiTag;
 import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
+import com.bungaebowling.server._core.commons.GeneralParameters;
 import com.bungaebowling.server._core.errors.exception.ErrorCode;
 import com.bungaebowling.server._core.security.JwtProvider;
 import com.bungaebowling.server.user.Role;
@@ -629,15 +630,8 @@ class UserControllerTest extends ControllerTestConfig {
                                 ResourceSnippetParameters.builder()
                                         .tag(ApiTag.USER.getTagName())
                                         .queryParameters(
-                                                parameterWithName("key").optional().type(SimpleType.NUMBER)
-                                                        .description("""
-                                                                검색 기준 id
-                                                                                                                
-                                                                처음 요청 시 key 없이 요청 | 2번째 요청부터는 response.nextCursorRequest.key 값으로 요청
-                                                                                                                
-                                                                더이상 가져올 값이 없을 시 nextCursorRequest.key로 -1 응답
-                                                                """),
-                                                parameterWithName("size").optional().type(SimpleType.NUMBER).defaultValue(20).description("한번에 가져올 크기")
+                                                GeneralParameters.CURSOR_KEY.getParameterDescriptorWithType(),
+                                                GeneralParameters.SIZE.getParameterDescriptorWithType()
                                         )
                                         .build()
                         )

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -1,9 +1,9 @@
 package com.bungaebowling.server.user.controller;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.bungaebowling.server.ApiTag;
 import com.bungaebowling.server.ControllerTestConfig;
-import com.bungaebowling.server.GeneralApiResponseSchema;
+import com.bungaebowling.server._core.commons.ApiTag;
+import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
 import com.bungaebowling.server._core.errors.exception.ErrorCode;
 import com.bungaebowling.server._core.security.JwtProvider;
 import com.bungaebowling.server.user.Role;


### PR DESCRIPTION
## Summary

댓글 조회에 대한 테스트 코드를 작성하였습니다. 작업을 하며 테스트 용 더미 데이터(댓글)을 추가하였고 유저 테스트에서 key와 size가 query parameter로 추가되지 않은 점을 고쳤습니다.

## Description

테스트 데이터에서 유저 2는 메일 인증이 안된 유저로 1, 3,4,5의 유저를 사용하여 더미 댓글을 생성하였습니다.

테스트를 하는 도중 댓글 api에 삭제된 댓글의 유저에 대한 null 처리가 안된 점을 발견하였고 수정하였습니다.
- 댓글의 경우 삭제 시 민감정보만 없애고 데이터는 남겨둡니다.
- 따라서 삭제된 댓글도 select가 가능하고 이때 댓글의 유저는 null로 되어 있습니다.
- 그렇기에 댓글 유저가 null 인경우에 대해 예외처리를 추가하였습니다.

사용자 목록 조회에서 key, size의 query parameter에 대해 작성되지 않은 점을 발견하였습니다.
- key, size를 사용하는 테스트를 하나 더 추가하여 해결하였습니다.
- 댓글 조회에서도 key와 size가 필요하여 만들었습니다.

key, size에 대한 문구등을 통일하고 한군데서 관리하여 재사용을 하기 위해 generalParameters Enum class를 만들었습니다.

기존의 ApiTag와 GeneralApiResponseSchema에 추가로 GeneralParameters까지 존재하니 지저분하여 _core.commons 패키지로 리팩토링하였습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: #63 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->