### PR TITLE
댓글 api 테스트 및 문서 작성 완료

### DIFF
--- a/src/main/java/com/bungaebowling/server/comment/Comment.java
+++ b/src/main/java/com/bungaebowling/server/comment/Comment.java
@@ -19,6 +19,8 @@ import java.time.LocalDateTime;
 @Table(name = "comment_tb")
 public class Comment {
 
+    public static final String DELETED_COMMENT_CONTENT = "삭제된 댓글입니다.";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -65,7 +67,7 @@ public class Comment {
     }
 
     public void delete() {
-        this.content = "삭제된 댓글입니다.";
+        this.content = DELETED_COMMENT_CONTENT;
         this.user = null;
     }
 }

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
         return ResponseEntity.ok()
                 .header(JwtProvider.HEADER, responseDto.access())
                 .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
-                .body(ApiUtils.success());
+                .body(ApiUtils.success(new UserResponse.CreateDto(responseDto.savedId())));
     }
 
     @PostMapping("/login")

--- a/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserResponse.java
@@ -103,4 +103,7 @@ public class UserResponse {
             String refresh
     ) {
     }
+
+    public record CreateDto(Long id) {
+    }
 }

--- a/src/test/java/com/bungaebowling/server/_core/commons/GeneralApiResponseSchema.java
+++ b/src/test/java/com/bungaebowling/server/_core/commons/GeneralApiResponseSchema.java
@@ -30,6 +30,15 @@ public enum GeneralApiResponseSchema {
                     fieldWithPath("response.nextCursorRequest.key").description("다음 요청 cursor의 key"),
                     fieldWithPath("response.nextCursorRequest.size").description("다음 요청 cursor의 size")
             )
+    ),
+    CREATED(
+            "생성 응답 DTO",
+            new FieldDescriptors(
+                    fieldWithPath("status").type(SimpleType.NUMBER).description("응답 상태 정보"),
+                    fieldWithPath("response").type(SimpleType.STRING).optional().description("응답 body"),
+                    fieldWithPath("errorMessage").type(SimpleType.STRING).optional().description("에러 메시지"),
+                    fieldWithPath("response.id").type(SimpleType.NUMBER).description("생성된 데이터의 id")
+            )
     );
 
     private final String name;

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -27,8 +27,7 @@ import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.context.WebApplicationContext;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -210,6 +209,29 @@ class CommentControllerTest extends ControllerTestConfig {
                 status().isOk(),
                 jsonPath("$.status").value(200),
                 jsonPath("$.response.id").isNumber()
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("댓글 등록")
+                                        .description("""
+                                                모집글에 새로운 댓글을 등록합니다.
+                                                                                                
+                                                대댓글 등록은 별개의 api를 사용해주세요.
+                                                """)
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(parameterWithName("postId").description("댓글을 등록할 모집글 id"))
+                                        .requestSchema(Schema.schema("댓글 등록 요청 DTO"))
+                                        .requestFields(fieldWithPath("content").description("등록할 댓글 내용"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.CREATED.getName()))
+                                        .responseFields(GeneralApiResponseSchema.CREATED.getResponseDescriptor())
+                                        .build()
+                        )
+                )
         );
     }
 

--- a/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/comment/controller/CommentControllerTest.java
@@ -274,6 +274,30 @@ class CommentControllerTest extends ControllerTestConfig {
                 status().isOk(),
                 jsonPath("$.status").value(200),
                 jsonPath("$.response.id").isNumber()
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] createReply",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("대댓글 등록")
+                                        .description("""
+                                                댓글에 대댓글을 등록합니다.
+                                                """)
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(
+                                                parameterWithName("postId").description("대댓글을 등록할 모집글 id"),
+                                                parameterWithName("commentId").description("대댓글을 등록할 댓글 id")
+                                        )
+                                        .requestSchema(Schema.schema("댓글 등록 요청 DTO"))
+                                        .requestFields(fieldWithPath("content").description("등록할 댓글 내용"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.CREATED.getName()))
+                                        .responseFields(GeneralApiResponseSchema.CREATED.getResponseDescriptor())
+                                        .build()
+                        )
+                )
         );
     }
 
@@ -315,6 +339,26 @@ class CommentControllerTest extends ControllerTestConfig {
                 status().isNotFound(),
                 jsonPath("$.status").value(404),
                 jsonPath("$.response").value(ErrorCode.COMMENT_NOT_FOUND.toString())
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[comment] createReplyAtDeleted",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag(ApiTag.COMMENT.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(
+                                                parameterWithName("postId").description("대댓글을 등록할 모집글 id"),
+                                                parameterWithName("commentId").description("대댓글을 등록할 댓글 id")
+                                        )
+                                        .requestSchema(Schema.schema("댓글 등록 요청 DTO"))
+                                        .requestFields(fieldWithPath("content").description("등록할 댓글 내용"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.FAIL.getName()))
+                                        .responseFields(GeneralApiResponseSchema.FAIL.getResponseDescriptor())
+                                        .build()
+                        )
+                )
         );
     }
 

--- a/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/user/controller/UserControllerTest.java
@@ -110,7 +110,8 @@ class UserControllerTest extends ControllerTestConfig {
 
         resultActions.andExpectAll(
                 status().isOk(),
-                jsonPath("$.status").value(200)
+                jsonPath("$.status").value(200),
+                jsonPath("$.response.id").isNumber()
         ).andDo(
                 MockMvcRestDocumentationWrapper.document(
                         "[user] join",
@@ -143,8 +144,8 @@ class UserControllerTest extends ControllerTestConfig {
 
                                                         (e.g.)Bearer {jwt_access_token}""")
                                         )
-                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.SUCCESS.getName()))
-                                        .responseFields(GeneralApiResponseSchema.SUCCESS.getResponseDescriptor())
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.CREATED.getName()))
+                                        .responseFields(GeneralApiResponseSchema.CREATED.getResponseDescriptor())
                                         .build()
                         )
                 )


### PR DESCRIPTION
## Summary

댓글 등록, 대댓글 등록, 댓글 수정, 댓글 삭제를 추가하였습니다.

## Description

- 댓글 등록에 대한 테스트 생성도중 회원가입 시 id를 반환하지 않고 있던 버그를 발견해 수정하였습니다.
- 댓글 등록, 유저 등록, 모집글 등록 등등 생성 응답에 대한 General인 GeneralApiResponseSchema.CREATED를 추가하였습니다.
- 대댓글 등록에서 삭제된 댓글에 시도하는 실패 케이스를 추가하였습니다.
- 댓글 수정/삭제에서 자신의 것이 아닌 댓글에 시도하는 실패 케이스를 추가하였습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: #63 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->