### PR TITLE
비밀번호 관련 API 추가

### DIFF
--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     USER_NAME_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호가 일치하지 않습니다."),
 
     EMAIL_SEND_LIMIT_EXCEEDED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 이메일 전송 한도가 초과되었습니다. 내일 다시 시도해주세요."),
     PLACE_DETAILS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 볼링장입니다."),

--- a/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
+++ b/src/main/java/com/bungaebowling/server/_core/security/JwtProvider.java
@@ -24,6 +24,8 @@ public class JwtProvider {
     public static final String TYPE_REFRESH = "refresh";
     public static final String TYPE_EMAIL_VERIFICATION = "email-verification";
 
+    public static final String TYPE_EMAIL_VERIFICATION_PASSWORD = "email-verification-password";
+
     @Getter
     private static Long accessExpSecond;
     @Getter
@@ -79,6 +81,18 @@ public class JwtProvider {
                 .withExpiresAt(Timestamp.valueOf(expired))
                 .sign(Algorithm.HMAC512(secret));
     }
+
+    public static String createEmailVerificationForPassword(User user) {
+        LocalDateTime now = LocalDateTime.now();
+
+        LocalDateTime expired = now.plusDays(1); // 하루동안 유효
+        return JWT.create()
+                .withSubject(user.getId().toString())
+                .withClaim("type", TYPE_EMAIL_VERIFICATION_PASSWORD)
+                .withExpiresAt(Timestamp.valueOf(expired))
+                .sign(Algorithm.HMAC512(secret));
+    }
+
 
     public static DecodedJWT verify(String jwt, String type) {
         try {

--- a/src/main/java/com/bungaebowling/server/user/User.java
+++ b/src/main/java/com/bungaebowling/server/user/User.java
@@ -72,9 +72,15 @@ public class User {
         this.resultImageUrl = Objects.nonNull(resultImageUrl) ? resultImageUrl : this.resultImageUrl;
     }
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
     public String getDistrictName() {
         return this.district.getCountry().getCity().getName() + " " +
                 this.district.getCountry().getName() + " " +
                 this.district.getName();
     }
+
+
 }

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -126,9 +126,22 @@ public class UserController {
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }
 
-    @PatchMapping("users/password")
+    @PatchMapping("/users/password")
     public ResponseEntity<?> updatePassword(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody UserRequest.UpdatePasswordDto requestDto) {
         userService.updatePassword(userDetails.getId(), requestDto);
+        return ResponseEntity.ok().body(ApiUtils.success());
+    }
+
+    @PostMapping("/password/email-verification")
+    public ResponseEntity<?> sendVerificationMailForPasswordReset(@RequestBody UserRequest.SendVerificationMailForPasswordResetDto requestDto) {
+        userService.sendVerificationMailForPasswordReset(requestDto);
+        return ResponseEntity.ok().body(ApiUtils.success());
+    }
+
+
+    @PostMapping("/password/email-confirm")
+    public ResponseEntity<?> confirmEmailAndSendTempPassword(@RequestBody UserRequest.ConfirmEmailAndSendTempPasswordDto requestDto, Errors errors) {
+        userService.confirmEmailAndSendTempPassword(requestDto);
         return ResponseEntity.ok().body(ApiUtils.success());
     }
 

--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -80,6 +80,7 @@ public class UserController {
                 .body(response);
     }
 
+
     @PostMapping("/email-verification")
     public ResponseEntity<?> sendVerification(@AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.sendVerificationMail(userDetails.getId());
@@ -125,6 +126,12 @@ public class UserController {
         return ResponseEntity.ok().body(ApiUtils.success(response));
     }
 
+    @PatchMapping("users/password")
+    public ResponseEntity<?> updatePassword(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody UserRequest.UpdatePasswordDto requestDto) {
+        userService.updatePassword(userDetails.getId(), requestDto);
+        return ResponseEntity.ok().body(ApiUtils.success());
+    }
+
     private static ResponseCookie createRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true) // javascript 접근 방지
@@ -133,4 +140,6 @@ public class UserController {
                 .maxAge(JwtProvider.getRefreshExpSecond())
                 .build();
     }
+
+
 }

--- a/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
@@ -54,4 +54,18 @@ public class UserRequest {
             String token
     ) {
     }
+
+    public record ConfirmEmailAndSendTempPasswordDto(
+            @NotEmpty
+            String token
+    ) {
+    }
+
+    public record SendVerificationMailForPasswordResetDto(
+            @NotEmpty @Size(max = 100, message = "최대 100자까지 입니다.")
+            @Pattern(regexp = "^[\\w.%+-]+@[\\w.-]+\\.[A-Za-z]{2,}$", message = "이메일 형식이 아닙니다.")
+            String email
+    ) {
+    }
+
 }

--- a/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
+++ b/src/main/java/com/bungaebowling/server/user/dto/UserRequest.java
@@ -39,6 +39,16 @@ public class UserRequest {
         }
     }
 
+    public record UpdatePasswordDto(
+            @NotEmpty
+            @NotEmpty @Size(max = 64, message = "최대 64자까지 입력 가능합니다.")
+            String password,
+            @NotEmpty @Size(min = 8, max = 64, message = "8자에서 64자 이내여야 합니다.")
+            @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@#$%^&!])[a-zA-Z\\d@#$%^&!]+$", message = "영문, 숫자, 특수문자가 포함되어야 합니다.")
+            String newPassword
+    ) {
+    }
+
     public record ConfirmEmailDto(
             @NotEmpty
             String token

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -274,4 +274,13 @@ public class UserService {
     private Long getLastKey(List<User> users) {
         return users.isEmpty() ? CursorRequest.NONE_KEY : users.get(users.size() - 1).getId();
     }
+
+    @Transactional
+    public void updatePassword(Long userId, UserRequest.UpdatePasswordDto requestDto) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
+            throw new CustomException(ErrorCode.WRONG_PASSWORD);
+        }
+        user.updatePassword(passwordEncoder.encode(requestDto.newPassword()));
+    }
 }

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.bungaebowling.server.user.service;
 
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.bungaebowling.server._core.errors.exception.CustomException;
 import com.bungaebowling.server._core.errors.exception.ErrorCode;
 import com.bungaebowling.server._core.security.JwtProvider;
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
@@ -243,6 +245,59 @@ public class UserService {
         user.updateProfile(name, district, resultImageUrl, accessImageUrl);
     }
 
+    @Transactional
+    public void updatePassword(Long userId, UserRequest.UpdatePasswordDto requestDto) {
+        User user = findUserById(userId);
+        if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
+            throw new CustomException(ErrorCode.WRONG_PASSWORD);
+        }
+        user.updatePassword(passwordEncoder.encode(requestDto.newPassword()));
+    }
+
+
+    public void sendVerificationMailForPasswordReset(UserRequest.SendVerificationMailForPasswordResetDto requestDto) {
+        User user = userRepository.findByEmail(requestDto.email()).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String token = JwtProvider.createEmailVerificationForPassword(user);
+
+        String subject = "[번개볼링] 비밀번호 초기화 및 임시 비밀번호 발급을 위한 이메일 인증을 완료해주세요.";
+        String text = "<a href='" + domain + "/password/email-verification?token=" + token + "'>링크</a>를 클릭하여 인증을 완료해주세요!";
+
+        try {
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "utf-8");
+            helper.setTo(user.getEmail());
+            helper.setSubject(subject);
+            helper.setText(text, true);
+            javaMailSender.send(mimeMessage);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.EMAIL_SEND_LIMIT_EXCEEDED);
+        }
+    }
+
+    @Transactional
+    public void confirmEmailAndSendTempPassword(UserRequest.ConfirmEmailAndSendTempPasswordDto requestDto) {
+        DecodedJWT decodedJwt = JwtProvider.verify(requestDto.token(), JwtProvider.TYPE_EMAIL_VERIFICATION_PASSWORD);
+        User user = findUserById(Long.valueOf(decodedJwt.getSubject()));
+        String tempPassword = getRamdomPassword(15);
+        user.updatePassword(passwordEncoder.encode(tempPassword));
+
+        String subject = "[번개볼링] 임시 비밀번호";
+        String text = "임시 비밀번호는  " + tempPassword + "  입니다. <br>*비밀번호를 변경해주세요." + "<br>*기존의 비밀번호는 사용할 수 없습니다.";
+
+        try {
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "utf-8");
+            helper.setTo(user.getEmail());
+            helper.setSubject(subject);
+            helper.setText(text, true);
+            javaMailSender.send(mimeMessage);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.EMAIL_SEND_LIMIT_EXCEEDED);
+        }
+
+    }
+
     public UserResponse.GetRecordDto getRecords(Long userId) {
         User user = findUserById(userId);
         List<Score> scores = findScoreByUserId(userId);
@@ -275,12 +330,24 @@ public class UserService {
         return users.isEmpty() ? CursorRequest.NONE_KEY : users.get(users.size() - 1).getId();
     }
 
-    @Transactional
-    public void updatePassword(Long userId, UserRequest.UpdatePasswordDto requestDto) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        if (!passwordEncoder.matches(requestDto.password(), user.getPassword())) {
-            throw new CustomException(ErrorCode.WRONG_PASSWORD);
+    public String getRamdomPassword(int length) {
+        char[] charSet = new char[]{
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+                '!', '@', '#', '$', '%', '^', '&'};
+
+        SecureRandom random = new SecureRandom();
+        StringBuilder stringBuilder = new StringBuilder();
+
+        int charSetLength = charSet.length;
+        for (int i = 0; i < length; i++) {
+            stringBuilder.append(charSet[random.nextInt(charSetLength)]);
         }
-        user.updatePassword(passwordEncoder.encode(requestDto.newPassword()));
+
+        return stringBuilder.toString();
+
     }
+
+
 }


### PR DESCRIPTION
## Summary

- 비밀번호 변경 API를 추가하였습니다.
- 비밀번호 찾기(초기화) API를 추가하였습니다.

## Description

비밀번호 찾기 API를 구현 하면서 로직에 대해서 고민을 하였는데요. 현재 상태에서 가성비 좋게 구현하려고 방법을 생각하니 아래 3가지 방법이 떠올랐습니다.

1. (이메일, 지역코드) 를 입력 받아서 등록된 이메일로 임시 비밀번호를 발송해주는 방법

2. 메일인증 후 비밀번호를 메일로 보내는 방법

3. 2번과 유사한 방법이지만 메일을 2개 보내지 않고 비밀번호 정보는 따로 보여주는 페이지를 만든다.

결론적으로 2번 방식으로 구현을 하였습니다.
프론트쪽에서는 3가지 모두 그리 오래 걸리지 않는다고 하여 백엔드쪽의 결정에 따른다고 합니다.
1번의 경우 악의적으로 비밀번호초기화 공격을 할 가능성도 있기 때문에 2,3번 방법이 더욱 안정적이라 생각하였고
2,3 번의 경우 크게 차이는 없지만  2번방식이 조금 더 안정적인 것 같아 선택했습니다.
3번의 경우에는 메일에서 링크를 클릭하면 바로 새로운 창이 뜨면서 비밀번호를 보여주기 때문에 사용자 측면에서는 조금 더 자연스러울 수 있을 것 같습니다. 다만 리스폰스에 임시비밀번호가 담겨오기 때문에 보안쪽으로 문제가 없는지 걱정됩니다.(제 생각에는 크게 문제 없어보이긴합니다.)

2,3번 중에 어떠한 방식이 좋다고 생각하는지 궁금합니다.
수정하는게 크게 어렵지 않기 때문에 여러분들의 의견을 들어보고 수정 후 머지하겠습니다.

## Related Issue

Issue Number:  close #104
