### PR TITLE
참여 기록 조회, 프로필 수정 버그 수정

### DIFF
--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     USER_NAME_DUPLICATED(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    USER_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "프로필 수정에 실패하였습니다."),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호가 일치하지 않습니다."),
 
     EMAIL_SEND_LIMIT_EXCEEDED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 이메일 전송 한도가 초과되었습니다. 내일 다시 시도해주세요."),

--- a/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
+++ b/src/main/java/com/bungaebowling/server/_core/errors/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패하였습니다."),
     INVALID_FILE_UPLOAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 파일 업로드 요청입니다."),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 확장자입니다."),
+    FILE_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "잘못된 파일 요청입니다."),
 
     SCORE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "점수 등록에 실패하였습니다."),
     SCORE_UPDATE_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "점수 정보에 대한 수정 권한이 없습니다."),

--- a/src/main/java/com/bungaebowling/server/_core/utils/CommonUtils.java
+++ b/src/main/java/com/bungaebowling/server/_core/utils/CommonUtils.java
@@ -13,12 +13,7 @@ public class CommonUtils {
 
     // 점수 등록용
     public static String buildScoreFileName(Long userId, Long postId, String category, LocalDateTime time, String originalFileName) {
-        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR); // 파일 확장자 구분선
-
-        if (fileExtensionIndex == -1) {
-            throw new CustomException(ErrorCode.FILE_REQUEST_FAILED);
-        }
-
+        int fileExtensionIndex = getFileExtensionIndex(originalFileName);
         String fileExtension = originalFileName.substring(fileExtensionIndex); // 파일 확장자
         String fileName = originalFileName.substring(0, fileExtensionIndex); // 파일 이름
         String now = String.valueOf(time); // 파일 업로드 시간
@@ -29,18 +24,22 @@ public class CommonUtils {
 
     //프로필 등록
     public static String buildProfileFileName(Long userId, String category, LocalDateTime time, String originalFileName) {
-        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR); // 파일 확장자 구분선
-
-        if (fileExtensionIndex == -1) {
-            throw new CustomException(ErrorCode.FILE_REQUEST_FAILED);
-        }
-
+        int fileExtensionIndex = getFileExtensionIndex(originalFileName);
         String fileExtension = originalFileName.substring(fileExtensionIndex); // 파일 확장자
         String fileName = originalFileName.substring(0, fileExtensionIndex); // 파일 이름
         String now = String.valueOf(time); // 파일 업로드 시간
 
         //작성자(user_1)/profile/파일명/파일업로드시간.확장자
         return "user" + WORD_SEPARATOR + userId + CATEGORY_PREFIX + category + CATEGORY_PREFIX + fileName + TIME_SEPARATOR + now + fileExtension;
+    }
+
+    private static int getFileExtensionIndex(String originalFileName) {
+        int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR); // 파일 확장자 구분선
+
+        if (fileExtensionIndex == -1) {
+            throw new CustomException(ErrorCode.FILE_REQUEST_FAILED);
+        }
+        return fileExtensionIndex;
     }
 
     // 단일 파일용 -> 이것도 사용 용도에 맞게 custom해서 써야 함

--- a/src/main/java/com/bungaebowling/server/_core/utils/CommonUtils.java
+++ b/src/main/java/com/bungaebowling/server/_core/utils/CommonUtils.java
@@ -1,5 +1,8 @@
 package com.bungaebowling.server._core.utils;
 
+import com.bungaebowling.server._core.errors.exception.CustomException;
+import com.bungaebowling.server._core.errors.exception.ErrorCode;
+
 import java.time.LocalDateTime;
 
 public class CommonUtils {
@@ -11,6 +14,11 @@ public class CommonUtils {
     // 점수 등록용
     public static String buildScoreFileName(Long userId, Long postId, String category, LocalDateTime time, String originalFileName) {
         int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR); // 파일 확장자 구분선
+
+        if (fileExtensionIndex == -1) {
+            throw new CustomException(ErrorCode.FILE_REQUEST_FAILED);
+        }
+
         String fileExtension = originalFileName.substring(fileExtensionIndex); // 파일 확장자
         String fileName = originalFileName.substring(0, fileExtensionIndex); // 파일 이름
         String now = String.valueOf(time); // 파일 업로드 시간
@@ -22,6 +30,11 @@ public class CommonUtils {
     //프로필 등록
     public static String buildProfileFileName(Long userId, String category, LocalDateTime time, String originalFileName) {
         int fileExtensionIndex = originalFileName.lastIndexOf(FILE_EXTENSION_SEPARATOR); // 파일 확장자 구분선
+
+        if (fileExtensionIndex == -1) {
+            throw new CustomException(ErrorCode.FILE_REQUEST_FAILED);
+        }
+
         String fileExtension = originalFileName.substring(fileExtensionIndex); // 파일 확장자
         String fileName = originalFileName.substring(0, fileExtensionIndex); // 파일 이름
         String now = String.valueOf(time); // 파일 업로드 시간

--- a/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
+++ b/src/main/java/com/bungaebowling/server/post/dto/PostResponse.java
@@ -113,7 +113,8 @@ public class PostResponse {
                 Map<Long, List<User>> members,
                 Map<Long, List<UserRate>> rates,
                 Map<Long, Long> applicantIdMap,
-                Map<Long, Long> currentNumberMap
+                Map<Long, Long> currentNumberMap,
+                Map<Long, String> districtNameMap
         ) {
             return new GetParticipationRecordsDto(
                     nextCursorRequest,
@@ -124,7 +125,8 @@ public class PostResponse {
                                     members.get(post.getId()),
                                     rates.get(post.getId()),
                                     applicantIdMap.get(post.getId()),
-                                    currentNumberMap.get(post.getId())
+                                    currentNumberMap.get(post.getId()),
+                                    districtNameMap.get(post.getId())
                             )).toList()
             );
         }
@@ -141,13 +143,21 @@ public class PostResponse {
                 List<ScoreDto> scores,
                 List<MemberDto> members
         ) {
-            public PostDto(Post post, List<Score> scores, List<User> users, List<UserRate> rates, Long applicantId, Long currentNumber) {
+            public PostDto(
+                    Post post,
+                    List<Score> scores,
+                    List<User> users,
+                    List<UserRate> rates,
+                    Long applicantId,
+                    Long currentNumber,
+                    String districtName
+            ) {
                 this(
                         post.getId(),
                         applicantId,
                         post.getTitle(),
                         post.getDueTime(),
-                        post.getDistrictName(),
+                        districtName,
                         post.getStartTime(),
                         currentNumber,
                         post.getIsClose(),

--- a/src/main/java/com/bungaebowling/server/post/service/PostService.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostService.java
@@ -190,6 +190,7 @@ public class PostService {
         Map<Long, List<UserRate>> rateMap = getRateMap(userId, posts, applicantMap);
         Map<Long, Long> applicantIdMap = getApplicantIdMap(userId, posts, applicantMap);
         Map<Long, Long> currentNumberMap = getCurrentNumberMap(posts, applicantMap);
+        Map<Long, String> districtNameMap = getDistrictNameMap(posts);
 
         Long lastKey = getLastKey(posts);
         return PostResponse.GetParticipationRecordsDto.of(
@@ -199,7 +200,8 @@ public class PostService {
                 memberMap,
                 rateMap,
                 applicantIdMap,
-                currentNumberMap
+                currentNumberMap,
+                districtNameMap
         );
     }
 
@@ -271,6 +273,19 @@ public class PostService {
         return posts.stream().collect(Collectors.toMap(
                 Post::getId,
                 post -> (long) applicantMap.get(post.getId()).size()
+        ));
+    }
+
+    private Map<Long, String> getDistrictNameMap(List<Post> posts) {
+        return posts.stream().collect(Collectors.toMap(
+                Post::getId,
+                post -> {
+                    District district = districtRepository.findById(post.getDistrict().getId())
+                            .orElseThrow(() -> new CustomException(ErrorCode.REGION_NOT_FOUND));
+                    return district.getCountry().getCity().getName() + " " +
+                            district.getCountry().getName() + " " +
+                            district.getName();
+                }
         ));
     }
 

--- a/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
+++ b/src/main/java/com/bungaebowling/server/post/service/PostSpecification.java
@@ -1,8 +1,6 @@
 package com.bungaebowling.server.post.service;
 
 import com.bungaebowling.server.applicant.Applicant;
-import com.bungaebowling.server.city.country.Country;
-import com.bungaebowling.server.city.country.district.District;
 import com.bungaebowling.server.post.Post;
 import com.bungaebowling.server.user.User;
 import jakarta.persistence.criteria.*;
@@ -19,9 +17,6 @@ public class PostSpecification {
     public static Specification<Post> conditionEqual(String condition, Long userId) {
         return (root, query, criteriaBuilder) -> {
             Join<Post, User> userJoin = root.join("user", JoinType.LEFT);
-            Fetch<Post, District> districtFetch = root.fetch("district", JoinType.LEFT);
-            Fetch<District, Country> countryFetch = districtFetch.fetch("country", JoinType.LEFT);
-            countryFetch.fetch("city", JoinType.LEFT);
 
             Subquery<Long> subquery = query.subquery(Long.class);
             Root<Applicant> applicantRoot = subquery.from(Applicant.class);

--- a/src/main/java/com/bungaebowling/server/user/repository/UserRepository.java
+++ b/src/main/java/com/bungaebowling/server/user/repository/UserRepository.java
@@ -13,6 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByName(String name);
 
+    Boolean existsByName(String name);
+
     List<User> findAllByNameContainingOrderByIdDesc(@Param("name") String name, Pageable pageable);
 
     List<User> findAllByNameContainingAndIdLessThanOrderByIdDesc(@Param("name") String name, @Param("key") Long key, Pageable pageable);

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -219,10 +219,14 @@ public class UserService {
                         () -> new CustomException(ErrorCode.REGION_NOT_FOUND)
                 );
 
-        if (profileImage == null) {
-            user.updateProfile(name, district, null, null);
-        } else {
-            updateProfileWithImage(user, name, district, profileImage);
+        try {
+            if (profileImage == null) {
+                user.updateProfile(name, district, null, null);
+            } else {
+                updateProfileWithImage(user, name, district, profileImage);
+            }
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.USER_UPDATE_FAILED);
         }
     }
 

--- a/src/main/java/com/bungaebowling/server/user/service/UserService.java
+++ b/src/main/java/com/bungaebowling/server/user/service/UserService.java
@@ -210,6 +210,10 @@ public class UserService {
 
         User user = findUserById(userId);
 
+        if (userRepository.existsByName(name)) {
+            throw new CustomException(ErrorCode.USER_NAME_DUPLICATED);
+        }
+
         District district = districtId == null ? null :
                 districtRepository.findById(districtId).orElseThrow(
                         () -> new CustomException(ErrorCode.REGION_NOT_FOUND)


### PR DESCRIPTION
## Summary

- 참여 기록 조회 distinct join fetch 이슈
- 프로필 수정 이름 중복 500 에러 이슈
- 프로필 수정 이미지 파일 index 이슈

위의 이슈들을 해결했습니다.

## Description

### 참여 기록 조회 distinct join fetch 이슈
join fetch를 제거하고 distinct를 가져오는 쿼리를 분리했습니다. 

### 프로필 수정 이름 중복 500 에러 이슈
중복 이름 확인하고 try catch를 추가했습니다.

### 프로필 수정 이미지 파일 index 이슈
필드에 이미지가 첨부되지 않을 경우 index가 -1로 처리되는 오류가 발생했습니다. try catch에서 에러를 처리해줘서 이제는 큰 의미가 없는 것 같긴 하지만 안정성 있는 코드를 위해 index가 -1일 경우 예외를 처리하도록 수정했습니다. 점수 등록도 동일하게 변경했습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: close #102 
Issue Number: close #103
Issue Number: close #117
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->