### PR TITLE
ScoreController api 문서화 완료

### DIFF
--- a/src/main/resources/test_db/teardown.sql
+++ b/src/main/resources/test_db/teardown.sql
@@ -786,9 +786,9 @@ VALUES (1, null, 1, null, '삭제된 댓글입니다.'),
        (8, 7, 1, 1, '네 있습니다');
 
 -- 해당 post에 신청 수락되어야함 / 모집완료(is_close)되고 start가 지난 post에만 score 등록 /
-INSERT INTO score_tb (user_id, post_id, score_num)
-VALUES (1, 7, 100),
-       (1, 1, 150);
+INSERT INTO score_tb (id, user_id, post_id, score_num)
+VALUES (1, 1, 7, 100),
+       (2, 1, 1, 150);
 
 -- 해당 post에 신청 수락되어야함 / 모집완료(is_close)되고 start가 지난 post에만 score 등록 /
 INSERT INTO user_rate_tb(applicant_id, user_id, star_count)

--- a/src/main/resources/test_db/teardown.sql
+++ b/src/main/resources/test_db/teardown.sql
@@ -786,9 +786,9 @@ VALUES (1, null, 1, null, '삭제된 댓글입니다.'),
        (8, 7, 1, 1, '네 있습니다');
 
 -- 해당 post에 신청 수락되어야함 / 모집완료(is_close)되고 start가 지난 post에만 score 등록 /
-INSERT INTO score_tb (id, user_id, post_id, score_num)
-VALUES (1, 1, 7, 100),
-       (2, 1, 1, 150);
+INSERT INTO score_tb (id, user_id, post_id, score_num, result_image_url)
+VALUES (1, 1, 7, 100, null),
+       (2, 1, 1, 150, 'https://kakao.com');
 
 -- 해당 post에 신청 수락되어야함 / 모집완료(is_close)되고 start가 지난 post에만 score 등록 /
 INSERT INTO user_rate_tb(applicant_id, user_id, star_count)

--- a/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
@@ -1,16 +1,31 @@
 package com.bungaebowling.server.score.controller;
 
 import com.bungaebowling.server.ControllerTestConfig;
+import com.bungaebowling.server._core.commons.ApiTag;
+import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.context.WebApplicationContext;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
 @ActiveProfiles(value = {"test"})
@@ -26,6 +41,50 @@ class ScoreControllerTest extends ControllerTestConfig {
     @Test
     @DisplayName("점수 조회 테스트")
     void getScores() throws Exception {
+        // given
+        Long postId = 1L;
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .get("/api/posts/{postId}/scores", postId)
+        );
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200)
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[score] getScores",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("점수 조회")
+                                        .description("""
+                                                모집글의 점수들을 조회합니다.
+                                                """
+                                        )
+                                        .tag(ApiTag.SCORE.getTagName())
+                                        .pathParameters(parameterWithName("postId").description("모집글 id"))
+                                        .responseSchema(Schema.schema("점수 조회 응답 DTO"))
+                                        .responseFields(
+                                                GeneralApiResponseSchema.SUCCESS.getResponseDescriptor().and(
+                                                        fieldWithPath("response.scores").description("점수 목록"),
+                                                        fieldWithPath("response.scores[].id").description("점수의 ID(PK)"),
+                                                        fieldWithPath("response.scores[].scoreNum").description("볼링 점수"),
+                                                        fieldWithPath("response.scores[].scoreImage").optional().type(SimpleType.STRING).description("점수 첨부 이미지 경로")
+                                                )
+                                        )
+                                        .build()
+                        )
+                )
+        );
     }
 
     @Test

--- a/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
@@ -1,8 +1,12 @@
 package com.bungaebowling.server.score.controller;
 
+import com.amazonaws.services.s3.AmazonS3;
 import com.bungaebowling.server.ControllerTestConfig;
 import com.bungaebowling.server._core.commons.ApiTag;
 import com.bungaebowling.server._core.commons.GeneralApiResponseSchema;
+import com.bungaebowling.server._core.security.JwtProvider;
+import com.bungaebowling.server.user.Role;
+import com.bungaebowling.server.user.User;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
@@ -10,18 +14,29 @@ import com.epages.restdocs.apispec.SimpleType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.web.context.WebApplicationContext;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -32,6 +47,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Sql(value = "classpath:test_db/teardown.sql", config = @SqlConfig(encoding = "UTF-8"))
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 class ScoreControllerTest extends ControllerTestConfig {
+
+    @MockBean
+    private AmazonS3 amazonS3Client;
 
     @Autowired
     public ScoreControllerTest(WebApplicationContext context, ObjectMapper om) {
@@ -90,6 +108,83 @@ class ScoreControllerTest extends ControllerTestConfig {
     @Test
     @DisplayName("점수 등록 테스트")
     void createScore() throws Exception {
+        // given
+        Long postId = 1L;
+
+        var userId = 1L; // 김볼링
+
+        var accessToken = JwtProvider.createAccess(
+                User.builder()
+                        .id(userId)
+                        .role(Role.ROLE_USER)
+                        .build()
+        );
+
+        int score = 153;
+        MockMultipartFile file = new MockMultipartFile("image", "image.png", MediaType.IMAGE_PNG_VALUE, "mockImageData".getBytes());
+
+        String imageUrl = "https://kakao.com";
+
+        BDDMockito.given(amazonS3Client.putObject(Mockito.any())).willReturn(null);
+        BDDMockito.given(amazonS3Client.getUrl(Mockito.any(), Mockito.any())).willReturn(new URL(imageUrl));
+
+        // when
+        var builder = RestDocumentationRequestBuilders
+                .multipart("/api/posts/{postId}/scores", postId);
+        builder.with(new RequestPostProcessor() {
+            @Override
+            public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
+                request.setMethod("POST");
+                return request;
+            }
+        });
+        ResultActions resultActions = mvc.perform(
+                builder
+                        .file(file)
+                        .part(new MockPart("score", Integer.toString(score).getBytes(StandardCharsets.UTF_8)))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+        );
+
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200)
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[score] createScore",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("점수 등록")
+                                        .description("""
+                                                모집 완료되어 게임 플레이 한 이후(start_time 이후) 자신이 참여한 모집글에 점수 등록이 가능합니다.
+                                                                                                
+                                                - 파일은 png, jpg, gif, jpeg만 업로드 가능합니다.
+                                                - 파일은 10MB의 크기 제한이 존재합니다.
+                                                            
+                                                현재 사용 플러그인이 multipart/form-data의 파라미터에 대한 문서화가 지원되지 않습니다. (try it out 불가능)
+                                                                                                
+                                                | Part  | Type   | Description                  |
+                                                |-------|--------|------------------------------|
+                                                | score | number | 볼링 점수 (1~300)             |
+                                                | image | Binary | 점수판 사진 등 첨부 이미지 파일 |
+                                                                                                
+                                                 """)
+                                        .tag(ApiTag.SCORE.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(parameterWithName("postId").type(SimpleType.NUMBER).description("모집글 id"))
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.SUCCESS.getName()))
+                                        .responseFields(GeneralApiResponseSchema.SUCCESS.getResponseDescriptor())
+                                        .build()
+                        )
+                )
+        );
     }
 
     @Test

--- a/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
@@ -1,0 +1,50 @@
+package com.bungaebowling.server.score.controller;
+
+import com.bungaebowling.server.ControllerTestConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.web.context.WebApplicationContext;
+
+@AutoConfigureMockMvc
+@ActiveProfiles(value = {"test"})
+@Sql(value = "classpath:test_db/teardown.sql", config = @SqlConfig(encoding = "UTF-8"))
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class ScoreControllerTest extends ControllerTestConfig {
+
+    @Autowired
+    public ScoreControllerTest(WebApplicationContext context, ObjectMapper om) {
+        super(context, om);
+    }
+
+    @Test
+    @DisplayName("점수 조회 테스트")
+    void getScores() throws Exception {
+    }
+
+    @Test
+    @DisplayName("점수 등록 테스트")
+    void createScore() throws Exception {
+    }
+
+    @Test
+    @DisplayName("점수 수정 테스트")
+    void updateScore() throws Exception {
+    }
+
+    @Test
+    @DisplayName("점수 이미지 삭제 테스트")
+    void deleteScoreImage() throws Exception {
+    }
+
+    @Test
+    @DisplayName("점수 삭제 테스트")
+    void deleteScore() throws Exception {
+    }
+}

--- a/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
@@ -62,10 +62,13 @@ class ScoreControllerTest extends ControllerTestConfig {
         // given
         Long postId = 1L;
 
+        Long userId = 1L;
+
         // when
         ResultActions resultActions = mvc.perform(
                 RestDocumentationRequestBuilders
                         .get("/api/posts/{postId}/scores", postId)
+                        .param("userId", Long.toString(userId))
         );
         // then
         var responseBody = resultActions.andReturn().getResponse().getContentAsString();
@@ -90,6 +93,7 @@ class ScoreControllerTest extends ControllerTestConfig {
                                         )
                                         .tag(ApiTag.SCORE.getTagName())
                                         .pathParameters(parameterWithName("postId").description("모집글 id"))
+                                        .queryParameters(parameterWithName("userId").optional().type(SimpleType.NUMBER).description("점수를 확인할 사용자 id"))
                                         .responseSchema(Schema.schema("점수 조회 응답 DTO"))
                                         .responseFields(
                                                 GeneralApiResponseSchema.SUCCESS.getResponseDescriptor().and(

--- a/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
+++ b/src/test/java/com/bungaebowling/server/score/controller/ScoreControllerTest.java
@@ -342,5 +342,61 @@ class ScoreControllerTest extends ControllerTestConfig {
     @Test
     @DisplayName("점수 삭제 테스트")
     void deleteScore() throws Exception {
+        // given
+        Long postId = 1L;
+
+        Long scoreId = 2L;
+
+        var userId = 1L; // 김볼링
+
+        var accessToken = JwtProvider.createAccess(
+                User.builder()
+                        .id(userId)
+                        .role(Role.ROLE_USER)
+                        .build()
+        );
+
+        BDDMockito.willAnswer(invocation -> {
+            return null;
+        }).given(amazonS3Client).deleteObject(Mockito.any());
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                RestDocumentationRequestBuilders
+                        .delete("/api/posts/{postId}/scores/{scoreId}", postId, scoreId)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+        );
+
+        // then
+        var responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        Object json = om.readValue(responseBody, Object.class);
+        System.out.println("[response]\n" + om.writerWithDefaultPrettyPrinter().writeValueAsString(json));
+
+        resultActions.andExpectAll(
+                status().isOk(),
+                jsonPath("$.status").value(200)
+        ).andDo(
+                MockMvcRestDocumentationWrapper.document(
+                        "[score] deleteScore",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .summary("점수 삭제")
+                                        .description("""
+                                                점수 행을 완전히 삭제합니다.
+                                                 """)
+                                        .tag(ApiTag.SCORE.getTagName())
+                                        .requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("access token"))
+                                        .pathParameters(
+                                                parameterWithName("postId").type(SimpleType.NUMBER).description("모집글 id"),
+                                                parameterWithName("scoreId").type(SimpleType.NUMBER).description("점수 id")
+                                        )
+                                        .responseSchema(Schema.schema(GeneralApiResponseSchema.SUCCESS.getName()))
+                                        .responseFields(GeneralApiResponseSchema.SUCCESS.getResponseDescriptor())
+                                        .build()
+                        )
+                )
+        );
     }
 }


### PR DESCRIPTION
## Summary

ScoreController의 api들을 문서화 완료하였습니다.

## Description

- GET /api/posts/{postId}/scores
- POST /api/posts/{postId}/scores
- PUT /api/posts/{postId}/scores/{scoreId}
- DELETE /api/posts/{postId}/scores/{scoreId}
- DELETE /api/posts/{postId}/scores/{scoreId}/image

총 5개의 api를 문서화하였습니다.

## Related Issue

<!-- 관련된 issue가 존재하지 않으면 단락을 삭제해 해주세요. -->
Issue Number: #63 
<!-- issue를 해결한 PR이면 'close #이슈번호' 로 작성해주세요. -->