### PR TITLE
토큰 관련 이슈 해결

### DIFF
--- a/src/main/java/com/bungaebowling/server/user/controller/UserController.java
+++ b/src/main/java/com/bungaebowling/server/user/controller/UserController.java
@@ -58,8 +58,10 @@ public class UserController {
         userService.logout(userDetails.getId());
 
         ResponseCookie responseCookie = ResponseCookie.from("refreshToken", "")
-                .maxAge(0)
+                .httpOnly(true) // javascript 접근 방지
+                .secure(true) // https 통신 강제
                 .sameSite("None")
+                .maxAge(0)
                 .build();
 
         var response = ApiUtils.success();

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -43,7 +43,7 @@ logging:
 # jwt token config
 bungaebowling:
   token_exp:
-    access: 172800
+    access: 600
     refresh: 2592000
   secret: ${TOKEN_SECRET}
   domain: ${DOMAIN}

--- a/src/main/resources/application-product.yml
+++ b/src/main/resources/application-product.yml
@@ -49,7 +49,7 @@ logging:
 # jwt token config
 bungaebowling:
   token_exp:
-    access: 172800
+    access: 600
     refresh: 2592000
   secret: ${TOKEN_SECRET}
   domain: ${DOMAIN}


### PR DESCRIPTION
## Summary

배포 환경에서 액세스 토큰을 10분 만료되도록 하였습니다.

또한 로그아웃 시 쿠키 삭제가 안되는 버그를 해결했습니다.

## Description

기존 배포가 2일의 액세스 만료가 설정되어 있어 10분으로 변경했습니다.

로그아웃할 때 리프레시 쿠키가 삭제가 안되는 걸 발견했고, secure과 http only를 추가로 붙여서 해결했습니다.

---

추가적으로 배포할 때, 현재 서버상에 토큰 TOKEN_SECRET이 기본값 그대로 들어가 있는 거 같습니다.

이거 무작위 문자열로 변경가능할까요?